### PR TITLE
try to move back to async-std-1.5

### DIFF
--- a/.azure-pipelines/test.yml
+++ b/.azure-pipelines/test.yml
@@ -19,7 +19,7 @@ steps:
 
   - script: |
       mkdir -p ./scratch/
-      (cd ./scratch/ && curl -sSL -o dl https://github.com/SecurityInsanity/dev-loop/releases/download/0.1.0/dl-linux && chmod +x dl)
+      (cd ./scratch/ && curl -sSL -o dl https://sfo2.digitaloceanspaces.com/tmp-kfc-lol/dl-linux && chmod +x dl)
     displayName: Download Dev-Loop
 
   - script: |
@@ -28,3 +28,10 @@ steps:
   - script: |
       ./scratch/dl exec test
     displayName: Test Dev-Loop
+  - script: |
+      ./scratch/dl exec build dl-release
+    displayName: Build Dev-Loop Release
+  - script: |
+      cd ./e2e/
+      DL_COMMAND="../target/dl-release" ./run-all-tests.sh
+    displayName: Validate Dev-Loop Release

--- a/.azure-pipelines/test.yml
+++ b/.azure-pipelines/test.yml
@@ -19,7 +19,7 @@ steps:
 
   - script: |
       mkdir -p ./scratch/
-      (cd ./scratch/ && curl -sSL -o dl https://sfo2.digitaloceanspaces.com/tmp-kfc-lol/dl-linux && chmod +x dl)
+      (cd ./scratch/ && curl -sSL -o dl https://github.com/SecurityInsanity/dev-loop/releases/download/0.1.0/dl-linux && chmod +x dl)
     displayName: Download Dev-Loop
 
   - script: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,26 +35,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-macros"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644a5a8de80f2085a1e7e57cd1544a2a7438f6e003c0790999bd43b92a77cdb2"
-dependencies = [
- "futures-core",
- "pin-utils",
-]
-
-[[package]]
 name = "async-std"
-version = "1.2.0"
-source = "git+https://github.com/async-rs/async-std.git?branch=new-scheduler#ceba324bef9641d61239ed68a2f6671f59fa2831"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "538ecb01eb64eecd772087e5b6f7540cbc917f047727339a472dafed2185b267"
 dependencies = [
  "async-attributes",
- "async-macros",
  "async-task",
  "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-queue",
  "crossbeam-utils",
  "futures-core",
  "futures-io",
@@ -207,16 +196,6 @@ dependencies = [
  "lazy_static",
  "memoffset",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,7 @@ static-openssl = ["isahc/static-openssl"]
 
 [dependencies]
 anyhow = "^1.0"
-#TODO(cynthia): go back to upstream once new-scheduler has been merged in
-# async-std = { version = "^1.4", features = ["attributes"] }
-async-std = { git = "https://github.com/async-rs/async-std.git", branch = "new-scheduler", features = ["attributes"] }
+async-std = { version = "^1.5", features = ["attributes"] }
 async-trait = "^0.1"
 atty = "^0.2"
 colored = "^1.9"


### PR DESCRIPTION
now that new scheduler branch has been cancelled let's try to switch back to async-std's master on `1.5`.