### PR TITLE
add in parallel-pipeline task type

### DIFF
--- a/docs/docs/introduction/getting-started.md
+++ b/docs/docs/introduction/getting-started.md
@@ -18,9 +18,9 @@ or run a one off task. Instead Dev-Loop is meant to be an abstraction point for 
 these tasks. What do you get out of this abstraction point though? Abstraction for no reason
 can be harmful afterall.
 
-If you just want to get started using dev-loop we recommend walking through the <a href="/docs/walkthrough/installing" class="internal-link">walkthrough</a>.
+NOTE: If you just want to get started using dev-loop we recommend walking through the <a href="/docs/walkthrough/installing" class="internal-link">walkthrough</a>.
 
-If you've used dev-loop before, and are just looking for the fields that can be configured, and what they do you probably want the <a href="/docs/schemas/provide-conf" class="internal-link">Schema Documentation</a>.
+NOTE: If you've used dev-loop before, and are just looking for the fields that can be configured, and what they do you probably want the <a href="/docs/schemas/provide-conf" class="internal-link">Schema Documentation</a>.
 
 ## What Does Dev-Loop Give Me? ##
 

--- a/docs/docs/schemas/task-conf.md
+++ b/docs/docs/schemas/task-conf.md
@@ -12,7 +12,7 @@ The name of the task. This needs to be unique across the entire project.
 
 - `type`: String [OPTIONAL]
 
-The type of task this is. Currently there are three supported options `command`, `oneof`, and `pipeline`.
+The type of task this is. Currently there are three supported options `command`, `oneof`, `pipeline`, and `parallel-pipeline`.
 If you do not specify a type `command` will be assumed.
 
 - `description`: String [OPTIONAL]
@@ -35,7 +35,7 @@ Represents a custom executor for this one task. In general we don't recommend se
 However there may be specific cases where you want to make it clear this task has needs for a very special executor.
 A `custom_executor` will always be selected if specified, and can still be reused within a pipeline.
 
-- `steps`: List[<a href="/docs/schemas/pipeline-step" class="internal-link">PipelineStep</a>] [REQUIRED for "pipeline" type tasks] [IGNORED for "command"/"oneof" tasks]
+- `steps`: List[<a href="/docs/schemas/pipeline-step" class="internal-link">PipelineStep</a>] [REQUIRED for "pipeline"/"parallel-pipeline" type tasks] [IGNORED for "command"/"oneof" tasks]
 
 An ordered list of steps to run when running a pipeline.
 If specified on a command/oneof task it will have no effect.
@@ -52,6 +52,6 @@ A list of tags to apply to this task. Tags can be selected by presets in order t
 - `internal`: Bool [OPTIONAL]
 
 Whether or not this task is "internal". If a task is internal it will not be shown on any list command, and
-cannot be run directly (it must be invoked through a `oneof`/`pipeline`).
+cannot be run directly (it must be invoked through a `oneof`/`pipeline`/`parallel-pipeline`).
 All internal tasks must be used at least once, or an error will occur because it would be impossible
 for that task to do anything.

--- a/docs/docs/schemas/top-level-conf.md
+++ b/docs/docs/schemas/top-level-conf.md
@@ -32,3 +32,29 @@ A list of of presets that can end up being run based on a series of tasks.
 - `task_locations`: List[<a href="/docs/schemas/location-conf" class="internal-link">LocationConf</a>] [OPTIONAL]
 
 A list of locations to search for `dl-tasks.yml`. These files have the type of <a href="/docs/schemas/task-conf-file" class="internal-link">TaskConfFile</a>.
+
+As a side note the following environment variables are supported with Dev-Loop:
+
+- `TMPDIR`: String [OPTIONAL]
+
+Used for controlling the temporary directory to mount/use in containers. OSX sets this automatically. If not specified `/tmp/` will be used.
+
+- `DL_WORKER_COUNT`: Unsigned Integer [OPTIONAL]
+
+Used to limit/control the number of workers that dev-loop will use in parallel scenarios.
+
+- `NO_COLOR`: Unset/Set [OPTIONAL]
+
+When no color is set to any value, there will be no color, or fancy text printed to the terminal.
+
+- `DL_FORCE_COLOR`: Boolean [OPTIONAL]
+
+A boolean to flip forcing color of dev-loop. Overrides the `NO_COLOR` setting. Can be useful when you want other tools to not output color that read from `NO_COLOR`, but allow dev-loop to still output color.
+
+- `DL_FORCE_STDOUT_COLOR`: Boolean [OPTIONAL]
+
+A boolean to force coloring output for things printed to STDOUT. Can be useful when dev-loop doesn't detect your terminal as something needing color.
+
+- `DL_FORCE_STDERR_COLOR`: Boolean [OPTIONAL]
+
+A boolean to force coloring output for things printed to STDERR. Can be useful when dev-loop doesn't detect your terminal as something needing color.

--- a/docs/docs/walkthrough/pipelines.md
+++ b/docs/docs/walkthrough/pipelines.md
@@ -11,6 +11,9 @@ A Pipeline runs a series of tasks in a guaranteed order, and much like oneof's t
 of arguments to pass to the underlying tasks so they remain declarative. A pipeline does not parallelize
 any of the work it's given, merely is a way of running tasks one after another (in a pipeline)!
 
+If you want a series of tasks that always run in parallel, switch from: `pipeline`, to `parallel-pipeline`,
+all the configuration is the same between the two.
+
 This can be useful for doing multi staged docker builds, or setting up something for another task,
 or in our case running multiple tests so you don't have to run one at a time! Much like we did for
 oneof we're going to introduce a new task to our task file:

--- a/e2e/run-all-tests.sh
+++ b/e2e/run-all-tests.sh
@@ -13,6 +13,39 @@ fi
 
 rm -rf ./build/
 $DL_COMMAND exec exec-pipeline
+
+# Run with parallelism
+$DL_COMMAND exec parallel-pipeline
+ppipeline_multi_data=$(< ./build/ppipeline/echo-nums)
+if [[ "$ppipeline_multi_data" != "1
+5
+7
+10" ]]; then
+  echo "Data: [$ppipeline_multi_data] is not: [1
+5
+7
+10]"
+  exit 1
+fi
+
+rm -f ./build/ppipeline/echo-nums
+
+# Run without parallelism
+export DL_WORKER_COUNT=1
+$DL_COMMAND exec parallel-pipeline
+unset DL_WORKER_COUNT
+ppipeline_single_data=$(< ./build/ppipeline/echo-nums)
+if [[ "$ppipeline_single_data" != "1
+7
+5
+10" ]]; then
+  echo "Data: [$ppipeline_single_data] is not: [1
+7
+5
+10]"
+  exit 2
+fi
+
 $DL_COMMAND run run
 
 data=$(< ./build/run/state)
@@ -29,4 +62,5 @@ if [[ "$data" != "1
 2
 3
 3]"
+  exit 3
 fi

--- a/e2e/tasks/exec/parallel-pipelines/dl-tasks.yml
+++ b/e2e/tasks/exec/parallel-pipelines/dl-tasks.yml
@@ -1,0 +1,63 @@
+---
+tasks:
+  - name: parallel-pipelines-pipeline-one-task-one
+    location:
+      type: path
+      at: pipeline-one/task-one.sh
+    execution_needs:
+      - name: host
+    internal: true
+  - name: parallel-pipelines-pipeline-one-task-two
+    location:
+      type: path
+      at: pipeline-one/task-two.sh
+    execution_needs:
+      - name: host
+    internal: true
+
+  - name: parallel-pipelines-pipeline-two-task-one
+    location:
+      type: path
+      at: pipeline-two/task-one.sh
+    execution_needs:
+      - name: host
+    internal: true
+
+  - name: parallel-pipelines-pipeline-three-task-one
+    location:
+      type: path
+      at: pipeline-three/task-one.sh
+    execution_needs:
+      - name: host
+    internal: true
+
+  - name: pipeline-one
+    type: pipeline
+    internal: true
+    steps:
+      - name: pipeline step one
+        task: parallel-pipelines-pipeline-one-task-one
+      - name: pipeline step two
+        task: parallel-pipelines-pipeline-one-task-two
+  - name: pipeline-two
+    type: pipeline
+    internal: true
+    steps:
+      - name: pipeline step one
+        task: parallel-pipelines-pipeline-two-task-one
+  - name: pipeline-three
+    type: pipeline
+    internal: true
+    steps:
+      - name: pipeline step one
+        task: parallel-pipelines-pipeline-three-task-one
+
+  - name: parallel-pipeline
+    type: parallel-pipeline
+    steps:
+      - name: pipeline one
+        task: pipeline-one
+      - name: pipeline two
+        task: pipeline-two
+      - name: pipeline three
+        task: pipeline-three

--- a/e2e/tasks/exec/parallel-pipelines/pipeline-one/task-one.sh
+++ b/e2e/tasks/exec/parallel-pipelines/pipeline-one/task-one.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+mkdir -p build/ppipeline/
+sleep 1
+echo "1" >> build/ppipeline/echo-nums

--- a/e2e/tasks/exec/parallel-pipelines/pipeline-one/task-two.sh
+++ b/e2e/tasks/exec/parallel-pipelines/pipeline-one/task-two.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+mkdir -p build/ppipeline/
+# This with the previous task should be 7 tasks
+sleep 6
+echo "7" >> build/ppipeline/echo-nums

--- a/e2e/tasks/exec/parallel-pipelines/pipeline-three/task-one.sh
+++ b/e2e/tasks/exec/parallel-pipelines/pipeline-three/task-one.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+mkdir -p build/ppipeline/
+sleep 10
+echo "10" >> build/ppipeline/echo-nums

--- a/e2e/tasks/exec/parallel-pipelines/pipeline-two/task-one.sh
+++ b/e2e/tasks/exec/parallel-pipelines/pipeline-two/task-one.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+mkdir -p build/ppipeline/
+sleep 5
+echo "5" >> build/ppipeline/echo-nums

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -132,7 +132,14 @@ pub async fn handle_exec_command(
 	}
 	let helpers = helpers_res.unwrap();
 
-	let rc_res = execute_tasks_in_parallel(helpers, worker, task_size, terminal, 1).await;
+	let mut parallelism = num_cpus::get_physical();
+	if let Ok(env_var) = std::env::var("DL_WORKER_COUNT") {
+		if let Ok(worker_count) = env_var.parse::<usize>() {
+			parallelism = worker_count;
+		}
+	}
+
+	let rc_res = execute_tasks_in_parallel(helpers, worker, task_size, terminal, parallelism).await;
 
 	match rc_res {
 		Ok(rc) => {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -114,14 +114,14 @@ pub async fn handle_run_command(
 		return 16;
 	}
 	let helpers = helpers_res.unwrap();
-	let rc_res = execute_tasks_in_parallel(
-		helpers,
-		worker,
-		task_size,
-		terminal,
-		num_cpus::get_physical(),
-	)
-	.await;
+
+	let mut parallelism = num_cpus::get_physical();
+	if let Ok(env_var) = std::env::var("DL_WORKER_COUNT") {
+		if let Ok(worker_count) = env_var.parse::<usize>() {
+			parallelism = worker_count;
+		}
+	}
+	let rc_res = execute_tasks_in_parallel(helpers, worker, task_size, terminal, parallelism).await;
 
 	match rc_res {
 		Ok(rc) => {

--- a/src/executors/mod.rs
+++ b/src/executors/mod.rs
@@ -46,10 +46,10 @@ pub trait Executor {
 	/// Execute a task.
 	///
 	/// `log_channel`: The channel to send log updates over.
-	/// `log_channel_err`: The channel to send log updates over for STDERR.
 	/// `should_stop`: a helper that tells us when we need to forcibly stop.
 	/// `helper_src_line`: the line that sources in all helper scripts.
 	/// `task`: The actual task to execute.
+	/// `worker_count`: The count of the worker we're placed on.
 	#[must_use]
 	async fn execute(
 		&self,
@@ -57,6 +57,7 @@ pub trait Executor {
 		should_stop: Arc<AtomicBool>,
 		helper_src_line: &str,
 		task: &ExecutableTask,
+		worker_count: usize,
 	) -> isize;
 }
 

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -118,13 +118,13 @@ impl TaskGraph {
 							));
 						}
 
-						// If it's a 'oneof' or 'pipeline' type, we need to parse it's children
-						// so we can ensure everything is valid.
+						// If it's a 'oneof', 'parallel-pipeline', or 'pipeline' type, we
+						// need to parse it's children so we can ensure everything is valid.
 						//
 						// We call `internal_task_names.remove()` always (it'll be a no-op if it
 						// doesn't contain the key). The `internal_task_names` are tasks that are marked
-						// `internal: true`, but don't yet have a reference. By being in a oneof/pipeline
-						// they themselves have a reference.
+						// `internal: true`, but don't yet have a reference. By being in a
+						// oneof/parallel-pipeline/pipeline they themselves have a reference.
 						//
 						// Next we check if the option "exists", if not. we add it to `unsatisfied_task_names`
 						// so it can be checked later.
@@ -141,7 +141,7 @@ impl TaskGraph {
 									}
 								}
 							}
-							"pipeline" => {
+							"parallel-pipeline" | "pipeline" => {
 								if let Some(steps) = task_conf.get_steps() {
 									for step in steps {
 										internal_task_names.remove(step.get_task_name());
@@ -170,7 +170,8 @@ impl TaskGraph {
 			}
 
 			if !allowing_dag_errors {
-				// If we had any tasks that we're in a 'oneof'/'pipeline', but we never
+				// If we had any tasks that we're in a
+				// 'oneof'/'parallel-pipeline'/'pipeline', but we never
 				// saw... go ahead and error.
 				if !unsatisfied_task_names.is_empty() {
 					return Err(anyhow!(


### PR DESCRIPTION
for when you need to run things in parallel without running based on tags.

- This also changes the task names in output to: `${worker_count}-${task_name}` for when a parallel pipeline is running tasks in parallel with the same name, everything outputs correctly.

- Also adds in: `DL_WORKER_COUNT` which allows you to control how many workers are spun up.