### PR TITLE
fix output, fix previous ignored clippy warnings

### DIFF
--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -3,7 +3,7 @@
 //! circumstances where we like powered off while running. However, it should
 //! always be safe to run.
 
-use crate::executors::{docker::DockerExecutor, host::HostExecutor};
+use crate::executors::{docker, host};
 
 use color_eyre::Result;
 use tracing::info;
@@ -19,8 +19,8 @@ pub async fn handle_clean_command() -> Result<()> {
 
 	info!("Cleaning resources ...");
 
-	HostExecutor::clean().await;
-	DockerExecutor::clean().await?;
+	host::Executor::clean().await;
+	docker::Executor::clean().await?;
 
 	info!("Cleaned.");
 	Ok(())

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -107,7 +107,6 @@ fn report_potential_internal_task_names<T>(
 /// - Error creating an executor/choosing an executor for tasks.
 /// - Error writing the helper scripts.
 /// - Error running the task.
-#[allow(clippy::cognitive_complexity)]
 pub async fn handle_exec_command(
 	config: &TopLevelConf,
 	fetcher: &FetcherRepository,
@@ -204,7 +203,7 @@ pub async fn handle_exec_command(
 		Ok(exit_code) => {
 			if exit_code == 0 {
 				// Don't cause an error for cleaning if the task succeeded, the user can always clean manually.
-				let _ = crate::executors::docker::DockerExecutor::clean().await;
+				let _ = crate::executors::docker::Executor::clean().await;
 				Ok(())
 			} else {
 				Err(eyre!(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,6 @@
 //! The overarching module for all particular commands implemented by Dev-Loop.
 
-pub mod clean;
-pub mod exec;
-pub mod list;
-pub mod run;
+pub(crate) mod clean;
+pub(crate) mod exec;
+pub(crate) mod list;
+pub(crate) mod run;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -30,7 +30,6 @@ use std::path::PathBuf;
 /// - Error creating an executor/choosing an executor for tasks.
 /// - Error writing the helper scripts.
 /// - Error running the task.
-#[allow(clippy::cognitive_complexity)]
 pub async fn handle_run_command(
 	config: &TopLevelConf,
 	fetcher: &FetcherRepository,
@@ -112,7 +111,7 @@ pub async fn handle_run_command(
 		Ok(exit_code) => {
 			if exit_code == 0 {
 				// Don't cause an error for cleaning if the task succeeded, the user can always clean manually.
-				let _ = crate::executors::docker::DockerExecutor::clean().await;
+				let _ = crate::executors::docker::Executor::clean().await;
 				Ok(())
 			} else {
 				Err(eyre!(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! Those validations happen at different stages within the program.
 
-use crate::yaml_err::contextualize_yaml_err;
+use crate::yaml_err::contextualize;
 use color_eyre::{eyre::WrapErr, Result, Section};
 use std::{
 	fs::{canonicalize, File},
@@ -13,13 +13,12 @@ use std::{
 };
 use tracing::{error, trace};
 
-pub mod types;
+pub(crate) mod types;
 
 /// Get the root of the project repository.
 ///
 /// This discovers the project directory automatically by looking at
 /// `std::env::current_dir()`, and walking the path up.
-#[allow(clippy::cognitive_complexity)]
 #[must_use]
 pub fn get_project_root() -> Option<PathBuf> {
 	// Get the current directory (this is where we start looking...)
@@ -79,7 +78,7 @@ fn find_and_open_project_config() -> Option<(File, PathBuf)> {
 /// # Errors
 ///
 /// - When there is error doing a file read on a found configuration file.
-pub fn get_top_level_config() -> Result<Option<types::TopLevelConf>> {
+pub fn get_top_level() -> Result<Option<types::TopLevelConf>> {
 	let config_fh_opt = find_and_open_project_config();
 	if config_fh_opt.is_none() {
 		error!("Could not find project configuration [.dl/config.yml] looking in current directory, and parent directories.");
@@ -92,7 +91,7 @@ pub fn get_top_level_config() -> Result<Option<types::TopLevelConf>> {
 	config_fh.read_to_string(&mut contents)?;
 
 	Ok(Some(
-		contextualize_yaml_err(
+		contextualize(
 			serde_yaml::from_str::<types::TopLevelConf>(&contents),
 			".dl/config.yml",
 			&contents,

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -45,6 +45,7 @@ pub struct ExecutorConf {
 
 impl ProvideConf {
 	/// Create a new implementation of `ProvideConf`
+	#[cfg(test)]
 	#[must_use]
 	pub fn new(name: String, version: Option<String>) -> Self {
 		Self { name, version }
@@ -274,6 +275,7 @@ pub struct NeedsRequirement {
 
 impl NeedsRequirement {
 	/// Create a new `NeedsRequirements`.
+	#[cfg(test)]
 	#[must_use]
 	pub fn new(name: String, version_matcher: Option<String>) -> Self {
 		Self {
@@ -332,6 +334,7 @@ impl PipelineStep {
 	}
 
 	/// Get the description of this `PipelineStep`
+	#[allow(unused)]
 	#[must_use]
 	pub fn get_description(&self) -> Option<&str> {
 		if let Some(desc) = &self.description {
@@ -564,12 +567,6 @@ pub struct TaskConfFile {
 }
 
 impl TaskConfFile {
-	/// Get the list of tasks from this configuration file.
-	#[must_use]
-	pub fn get_tasks(&self) -> &[TaskConf] {
-		&self.tasks
-	}
-
 	/// Set the task location for all the configuration items
 	/// in this file.
 	pub fn set_task_location(&mut self, loc: &str) {
@@ -593,12 +590,6 @@ pub struct ExecutorConfFile {
 }
 
 impl ExecutorConfFile {
-	/// Get the list of executors that this file added.
-	#[must_use]
-	pub fn get_executors(&self) -> &[ExecutorConf] {
-		&self.executors
-	}
-
 	/// Consume the representation of this `ExecutorConfFile`, and receive the executors.
 	#[must_use]
 	pub fn consume_and_get_executors(self) -> Vec<ExecutorConf> {

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -1,6 +1,9 @@
+use color_eyre::{eyre::WrapErr, Result, Section};
 use std::{
+	convert::TryFrom,
 	env,
 	ffi::{CStr, OsString},
+	fs::set_permissions,
 	mem,
 	path::PathBuf,
 	ptr,
@@ -12,6 +15,53 @@ cfg_if::cfg_if! {
   } else if #[cfg(win)] {
 		use std::os::windows::ffi::OsStringExt;
   }
+}
+
+/// Rewrite the temporary directory.
+pub fn rewrite_tmp_dir(host_tmp_dir: &str, path: &PathBuf) -> String {
+	let replacement_str = if host_tmp_dir.ends_with('/') {
+		"/tmp/"
+	} else {
+		"/tmp"
+	};
+
+	path.to_string_lossy()
+		.replace(&host_tmp_dir, replacement_str)
+}
+
+#[cfg(target_family = "unix")]
+pub fn mark_as_world_editable(path: &PathBuf) -> Result<()> {
+	use std::fs::Permissions;
+	use std::os::unix::fs::PermissionsExt;
+
+	let executable_permissions = Permissions::from_mode(0o666);
+	set_permissions(path, executable_permissions)
+		.map(|_| ())
+		.wrap_err(format!("Failed to mark file as editable which is needed: [{:?}]", path))
+		.suggestion("If the error isn't immediately clear, please file an issue as it's probably a bug in dev-loop with your system.")
+}
+
+#[cfg(not(target_family = "unix"))]
+pub fn mark_as_world_editable(path: &PathBuf) -> Result<()> {
+	Ok(())
+}
+
+#[cfg(target_family = "unix")]
+pub fn mark_file_as_executable(path: &PathBuf) -> Result<()> {
+	use std::fs::Permissions;
+	use std::os::unix::fs::PermissionsExt;
+
+	let executable_permissions = Permissions::from_mode(0o777);
+
+	set_permissions(path, executable_permissions)
+		.map(|_| ())
+		.wrap_err(format!("Failed to mark file as executable which is needed: [{:?}]", path))
+		.suggestion("If the error isn't immediately clear, please file an issue as it's probably a bug in dev-loop with your system.")
+}
+
+#[cfg(not(target_family = "unix"))]
+pub fn mark_file_as_executable(path: &PathBuf) -> Result<()> {
+	Ok(())
 }
 
 /// Get the temporary directory for this host.
@@ -35,48 +85,47 @@ pub fn get_tmp_dir() -> PathBuf {
 	}
 }
 
+#[cfg(any(target_os = "android", target_os = "ios", target_os = "emscripten"))]
+unsafe fn home_dir_fallback() -> Option<OsString> {
+	None
+}
+
+#[cfg(not(any(target_os = "android", target_os = "ios", target_os = "emscripten")))]
+unsafe fn home_dir_fallback() -> Option<OsString> {
+	let amt = match libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) {
+		n if n < 0 => 512 as usize,
+		n => usize::try_from(n).unwrap_or(512),
+	};
+	let mut buf = Vec::with_capacity(amt);
+	let mut passwd: libc::passwd = mem::zeroed();
+	let mut result = ptr::null_mut();
+	match libc::getpwuid_r(
+		libc::getuid(),
+		&mut passwd,
+		buf.as_mut_ptr(),
+		buf.capacity(),
+		&mut result,
+	) {
+		0 if !result.is_null() => {
+			let ptr = passwd.pw_dir as *const _;
+			let bytes = CStr::from_ptr(ptr).to_bytes();
+			if bytes.is_empty() {
+				None
+			} else {
+				Some(OsStringExt::from_vec(bytes.to_vec()))
+			}
+		}
+		_ => None,
+	}
+}
+
 /// Calculate the home directory of a user.
-#[allow(clippy::items_after_statements)]
 #[must_use]
 pub fn home_dir() -> Option<PathBuf> {
-	return env::var_os("HOME")
+	env::var_os("HOME")
 		.and_then(|h| if h.is_empty() { None } else { Some(h) })
-		.or_else(|| unsafe { fallback() })
-		.map(PathBuf::from);
-
-	#[cfg(any(target_os = "android", target_os = "ios", target_os = "emscripten"))]
-	unsafe fn fallback() -> Option<OsString> {
-		None
-	}
-	#[cfg(not(any(target_os = "android", target_os = "ios", target_os = "emscripten")))]
-	#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-	unsafe fn fallback() -> Option<OsString> {
-		let amt = match libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) {
-			n if n < 0 => 512 as usize,
-			n => n as usize,
-		};
-		let mut buf = Vec::with_capacity(amt);
-		let mut passwd: libc::passwd = mem::zeroed();
-		let mut result = ptr::null_mut();
-		match libc::getpwuid_r(
-			libc::getuid(),
-			&mut passwd,
-			buf.as_mut_ptr(),
-			buf.capacity(),
-			&mut result,
-		) {
-			0 if !result.is_null() => {
-				let ptr = passwd.pw_dir as *const _;
-				let bytes = CStr::from_ptr(ptr).to_bytes();
-				if bytes.is_empty() {
-					None
-				} else {
-					Some(OsStringExt::from_vec(bytes.to_vec()))
-				}
-			}
-			_ => None,
-		}
-	}
+		.or_else(|| unsafe { home_dir_fallback() })
+		.map(PathBuf::from)
 }
 
 #[cfg(test)]

--- a/src/executors/docker_engine/container.rs
+++ b/src/executors/docker_engine/container.rs
@@ -1,0 +1,305 @@
+use color_eyre::{eyre::eyre, Report, Result, Section};
+use std::{collections::HashMap, env::var as env_var, path::PathBuf};
+use tracing::warn;
+
+const CONTAINER_NAME_ARG: &str = "name_prefix";
+const HOSTNAME_ARG: &str = "hostname";
+const IMAGE_ARG: &str = "image";
+const ENV_TO_EXPORT_ARG: &str = "export_env";
+const MOUNTS_ARG: &str = "extra_mounts";
+const PERMISSION_HELPER_ARG: &str = "experimental_permission_helper";
+const TCP_PORTS_TO_EXPOSE_ARG: &str = "tcp_ports_to_expose";
+const USER_ARG: &str = "user";
+const UDP_PORTS_TO_EXPOSE_ARG: &str = "udp_ports_to_expose";
+
+/// Represents a `DockerContainer` managed by the docker-engine/docker executor.
+#[derive(Debug)]
+pub struct DockerContainerInfo {
+	/// The container name to use.
+	container_name: String,
+	/// The docker image.
+	image: String,
+	/// A list of environment variables to export.
+	environment_to_export: Vec<String>,
+	/// A list of extra mounts.
+	extra_mounts: Vec<String>,
+	/// The list of tcp ports to expose.
+	tcp_ports_to_expose: Vec<u32>,
+	/// The list of udp ports to expose.
+	udp_ports_to_expose: Vec<u32>,
+	/// The hostname of this container.
+	hostname: String,
+	/// The base user to use.
+	base_user: String,
+	/// The proxied user id.
+	proxy_user_id: Option<u32>,
+	/// The proxied group id.
+	proxy_group_id: Option<u32>,
+}
+
+impl DockerContainerInfo {
+	pub fn new(
+		executor_args: &HashMap<String, String>,
+		project_root_str: &str,
+		random_str: &str,
+	) -> Result<Self> {
+		let (proxy_user, proxy_group) = get_proxy_user_information(executor_args);
+
+		Ok(Self {
+			container_name: container_name_from_arg(executor_args, random_str)?,
+			image: image_from_arg(executor_args)?,
+			environment_to_export: get_env_vars_to_export(executor_args),
+			extra_mounts: get_extra_mounts(executor_args, project_root_str),
+			tcp_ports_to_expose: tcp_ports_to_expose(executor_args),
+			udp_ports_to_expose: udp_ports_to_expose(executor_args),
+			hostname: get_hostname(executor_args),
+			base_user: get_user(executor_args),
+			proxy_user_id: proxy_user,
+			proxy_group_id: proxy_group,
+		})
+	}
+
+	pub fn get_container_name(&self) -> &str {
+		&self.container_name
+	}
+
+	pub fn get_image(&self) -> &str {
+		&self.image
+	}
+
+	pub fn get_environment_to_export(&self) -> &[String] {
+		&self.environment_to_export
+	}
+
+	pub fn get_extra_mounts(&self) -> &[String] {
+		&self.extra_mounts
+	}
+
+	pub fn get_tcp_ports_to_expose(&self) -> &[u32] {
+		&self.tcp_ports_to_expose
+	}
+
+	pub fn get_udp_ports_to_expose(&self) -> &[u32] {
+		&self.udp_ports_to_expose
+	}
+
+	pub fn get_hostname(&self) -> &str {
+		&self.hostname
+	}
+
+	pub fn get_base_user(&self) -> &str {
+		&self.base_user
+	}
+
+	pub fn get_proxy_user_id(&self) -> Option<&u32> {
+		self.proxy_user_id.as_ref()
+	}
+
+	pub fn get_cloned_proxy_user_id(&self) -> Option<u32> {
+		self.proxy_user_id
+	}
+
+	pub fn get_proxy_group_id(&self) -> Option<&u32> {
+		self.proxy_group_id.as_ref()
+	}
+
+	pub fn get_cloned_proxy_group_id(&self) -> Option<u32> {
+		self.proxy_group_id
+	}
+}
+
+fn container_name_from_arg(args: &HashMap<String, String>, random_str: &str) -> Result<String> {
+	let mut container_name = "dl-".to_owned();
+	if let Some(user_specified_prefix) = args.get(CONTAINER_NAME_ARG) {
+		container_name += user_specified_prefix;
+	} else {
+		return Err(eyre!(
+			"Docker Container require a `name_prefix` field to know how to name containers!"
+		)).suggestion("Add a `name_prefix` field to `params` that specifys the name prefix for containers")
+			.note("You can find the full list of fields here: https://dev-loop.kungfury.io/docs/schemas/executor-conf");
+	}
+	container_name += &random_str;
+
+	Ok(container_name)
+}
+
+fn image_from_arg(args: &HashMap<String, String>) -> Result<String> {
+	let image;
+	if let Some(image_identifier) = args.get(IMAGE_ARG) {
+		image = image_identifier.to_owned();
+	} else {
+		return Err(eyre!(
+			"Docker Container requires an `image` to know which docker image to use."
+		)).suggestion("Add an `image` field to `params` that specifys the docker image to use.")
+			.note("You can find the full list of fields here: https://dev-loop.kungfury.io/docs/schemas/executor-conf");
+	}
+
+	Ok(image)
+}
+
+fn get_env_vars_to_export(args: &HashMap<String, String>) -> Vec<String> {
+	let mut env_vars = Vec::new();
+
+	if let Some(envs_to_export) = args.get(ENV_TO_EXPORT_ARG) {
+		env_vars = envs_to_export
+			.split(',')
+			.map(|the_str| {
+				env_var(the_str)
+					.map_or_else(|_| the_str.to_owned(), |val| format!("{}={}", the_str, val))
+			})
+			.collect::<Vec<String>>();
+	}
+
+	env_vars
+}
+
+fn get_extra_mounts(args: &HashMap<String, String>, project_root_str: &str) -> Vec<String> {
+	let mut extra_mounts = Vec::new();
+
+	if let Some(mount_str_ref) = args.get(MOUNTS_ARG) {
+		extra_mounts = mount_str_ref
+			.split(',')
+			.filter_map(|item| {
+				let mounts = item.split(':').collect::<Vec<&str>>();
+				if mounts.len() != 2 {
+					warn!(
+						"{:?}",
+						Err::<(), Report>(eyre!(
+							"Mount String for Docker Container: [{}] is invalid, missing path for container. Will not mount.",
+							item,
+						))
+						.note("Mounts should be in the format: `host_path:path_in_container`")
+						.unwrap_err()
+					);
+					return None;
+				}
+
+				let src = mounts[0];
+				let dest = mounts[1];
+
+				let src =
+					if src.starts_with('~') {
+						let potential_home_dir = crate::dirs::home_dir();
+						if potential_home_dir.is_none() {
+							warn!(
+								"{:?}",
+								Err::<(), Report>(eyre!(
+									"Mount String: [{}] for Docker Container's source path is relative to the home directory, but the home directory couldn't be found. Will not mount.",
+									item,
+								))
+								.suggestion("You can manually specify the home directory with the `HOME` environment variable.")
+								.unwrap_err()
+							);
+							return None;
+						}
+						let home_dir = potential_home_dir.unwrap();
+						let home_dir = home_dir.to_str();
+						if home_dir.is_none() {
+							warn!(
+								"{:?}",
+								Err::<(), Report>(eyre!(
+									"Home directory is not set to a UTF-8 only string."
+								)).note("If you're not sure how to solve this error, please open an issue.").unwrap_err(),
+							);
+							return None;
+						}
+						let home_dir = home_dir.unwrap();
+
+            src.replace("~", home_dir)
+					} else if src.starts_with('/') {
+						src.to_owned()
+					} else {
+						project_root_str.to_owned() + "/" + src
+					};
+
+        let src_as_pb = PathBuf::from(&src);
+				if !src_as_pb.exists() {
+					warn!(
+						"{:?}",
+						Err::<(), Report>(eyre!(
+							"Mount String: [{}] specified a source directory: [{}] that does not exist. Will not mount.",
+							item,
+							src,
+						)).unwrap_err(),
+					);
+					return None;
+				}
+
+					Some(format!("{}:{}", src, dest))
+				})
+				.collect::<Vec<String>>();
+	}
+
+	extra_mounts
+}
+
+fn tcp_ports_to_expose(args: &HashMap<String, String>) -> Vec<u32> {
+	let mut tcp_ports_to_expose = Vec::new();
+	if let Some(ports_to_expose) = args.get(TCP_PORTS_TO_EXPOSE_ARG) {
+		tcp_ports_to_expose = ports_to_expose
+			.split(',')
+			.filter_map(|item| {
+				let item_pr = item.parse::<u32>();
+				if item_pr.is_err() {
+					warn!(
+						"Not exposing tcp port: [{}] as it is not a valid positive number.",
+						item
+					);
+				}
+				item_pr.ok()
+			})
+			.collect::<Vec<u32>>();
+	}
+
+	tcp_ports_to_expose
+}
+
+fn udp_ports_to_expose(args: &HashMap<String, String>) -> Vec<u32> {
+	let mut udp_ports_to_expose = Vec::new();
+	if let Some(ports_to_expose) = args.get(UDP_PORTS_TO_EXPOSE_ARG) {
+		udp_ports_to_expose = ports_to_expose
+			.split(',')
+			.filter_map(|item| {
+				let item_pr = item.parse::<u32>();
+				if item_pr.is_err() {
+					warn!(
+						"Not exposing udp port: [{}] as it is not a valid positive number.",
+						item
+					);
+				}
+
+				item_pr.ok()
+			})
+			.collect::<Vec<u32>>();
+	}
+
+	udp_ports_to_expose
+}
+
+fn get_hostname(args: &HashMap<String, String>) -> String {
+	if let Some(hostname_ref) = args.get(HOSTNAME_ARG) {
+		hostname_ref.to_owned()
+	} else {
+		let mut string = args.get(CONTAINER_NAME_ARG).unwrap().to_owned();
+		string.pop();
+		string
+	}
+}
+
+fn get_user(args: &HashMap<String, String>) -> String {
+	args.get(USER_ARG)
+		.map_or_else(|| "root".to_owned(), String::from)
+}
+
+fn get_proxy_user_information(args: &HashMap<String, String>) -> (Option<u32>, Option<u32>) {
+	let mut proxy_user_id = None;
+	let mut proxy_group_id = None;
+	if let Some(permission_helper_active) = args.get(PERMISSION_HELPER_ARG) {
+		if &permission_helper_active.to_ascii_lowercase() == "true" {
+			proxy_user_id = Some(users::get_effective_uid());
+			proxy_group_id = Some(users::get_effective_gid());
+		}
+	}
+
+	(proxy_user_id, proxy_group_id)
+}

--- a/src/executors/docker_engine/container_api.rs
+++ b/src/executors/docker_engine/container_api.rs
@@ -1,0 +1,294 @@
+use super::{
+	docker_api_delete, docker_api_get, docker_api_post, download_image,
+	execute_command_in_container, get_command_exit_code, setup_permission_helper,
+	DockerContainerInfo,
+};
+
+use color_eyre::{
+	eyre::{eyre, WrapErr},
+	Result, Section,
+};
+use isahc::HttpClient;
+
+/// List all the devloop containers.
+pub async fn list_devloop_containers(client: &HttpClient) -> Result<Vec<String>> {
+	let resp = docker_api_get(
+		client,
+		"/containers/json?all=true",
+		"Taking awhile to query containers from docker. Will wait up to 30 seconds.".to_owned(),
+		None,
+		true,
+	)
+	.await?;
+	let mut container_names = Vec::new();
+
+	if let Some(containers) = resp.as_array() {
+		for container in containers {
+			let names_opt = container.get("Names");
+			if names_opt.is_none() {
+				continue;
+			}
+
+			let names_untyped = names_opt.unwrap();
+			let names_typed_opt = names_untyped.as_array();
+			if names_typed_opt.is_none() {
+				continue;
+			}
+			let names = names_typed_opt.unwrap();
+
+			let mut dl_name = String::new();
+			for name in names {
+				if let Some(name_str) = name.as_str() {
+					if name_str.starts_with("/dl-") {
+						dl_name = name_str.to_owned();
+					}
+				}
+			}
+
+			if dl_name.is_empty() {
+				continue;
+			}
+
+			container_names.push(dl_name);
+		}
+	}
+
+	Ok(container_names)
+}
+
+pub async fn delete_container(client: &HttpClient, container_name: &str) {
+	let _ = docker_api_post(
+		client,
+		&format!("/containers{}/kill", container_name),
+		"Docker is not killing the container in a timely manner. Will wait up to 30 seconds."
+			.to_owned(),
+		None,
+		None,
+		false,
+	)
+	.await;
+	let _ = docker_api_delete(
+		&client,
+		&format!("/containers{}?v=true&force=true&link=true", container_name),
+		"Docker is taking awhile to remove the container. Will wait up to 30 seconds.".to_owned(),
+		None,
+		None,
+		false,
+	)
+	.await;
+}
+
+/// Determine if the container is created, and then if it's wondering.
+///
+/// # Errors
+///
+/// Errors when the docker api cannot be talked to.
+pub async fn is_container_created_and_running(
+	client: &HttpClient,
+	container_name: &str,
+) -> Result<(bool, bool)> {
+	let url = format!("/containers/{}/json?size=false", container_name);
+	let mut is_created = false;
+	let mut is_running = false;
+
+	// Ignore errors since a 404 for no container is an Error.
+	if let Ok(value) = docker_api_get(
+		client,
+		&url,
+		"Taking awhile to query container status from docker. Will wait up to 30 seconds."
+			.to_owned(),
+		None,
+		true,
+	)
+	.await
+	{
+		is_created = true;
+		let is_running_status = &value["State"]["Running"];
+		if is_running_status.is_boolean() {
+			is_running = is_running_status.as_bool().unwrap();
+		}
+	}
+
+	Ok((is_created, is_running))
+}
+
+/// Creates the container, should only be called when it does not yet exist.
+///
+/// # Errors
+///
+/// Errors when the docker socket cannot be talked too, or there is a conflict
+/// creating the container.
+pub async fn create_container(
+	client: &HttpClient,
+	project_root: &str,
+	tmp_dir: &str,
+	docker_container: &DockerContainerInfo,
+) -> Result<()> {
+	let mut mounts = Vec::new();
+	mounts.push(serde_json::json!({
+		"Source": project_root,
+		"Target": "/mnt/dl-root",
+		"Type": "bind",
+		"Consistency": "consistent",
+	}));
+	mounts.push(serde_json::json!({
+		"Source": tmp_dir,
+		"Target": "/tmp",
+		"Type": "bind",
+		"Consistency": "consistent",
+	}));
+	for emount in docker_container.get_extra_mounts() {
+		let mut split = emount.split(':');
+		let source: &str = split.next().unwrap();
+		let target: &str = split.next().unwrap();
+		mounts.push(serde_json::json!({
+			"Source": source,
+			"Target": target,
+			"Type": "bind",
+			"Consistency": "consistent",
+		}));
+	}
+
+	let mut port_mapping = serde_json::map::Map::<String, serde_json::Value>::new();
+	let mut host_config_mapping = serde_json::map::Map::<String, serde_json::Value>::new();
+
+	for tcp_port in docker_container.get_tcp_ports_to_expose() {
+		port_mapping.insert(format!("{}/tcp", tcp_port), serde_json::json!({}));
+		host_config_mapping.insert(
+			format!("{}/tcp", tcp_port),
+			serde_json::json!([serde_json::json!({ "HostPort": format!("{}", tcp_port) }),]),
+		);
+	}
+	for udp_port in docker_container.get_udp_ports_to_expose() {
+		port_mapping.insert(format!("{}/udp", udp_port), serde_json::json!({}));
+		host_config_mapping.insert(
+			format!("{}/udp", udp_port),
+			serde_json::json!([serde_json::json!({ "HostPort": format!("{}", udp_port) }),]),
+		);
+	}
+
+	let url = format!(
+		"/containers/create?name={}",
+		docker_container.get_container_name()
+	);
+	let body = serde_json::json!({
+		"Cmd": ["tail", "-f", "/dev/null"],
+		"Entrypoint": "",
+		"Image": docker_container.get_image(),
+		"Hostname": docker_container.get_hostname(),
+		"User": docker_container.get_base_user(),
+		"HostConfig": {
+			"AutoRemove": true,
+			"Mounts": mounts,
+			"Privileged": true,
+			"PortBindings": host_config_mapping,
+		},
+		"WorkingDir": "/mnt/dl-root",
+		"AttachStdout": true,
+		"AttachStderr": true,
+		"Privileged": true,
+		"Tty": true,
+		"ExposedPorts": port_mapping,
+	});
+	let _ = docker_api_post(
+		client,
+		&url,
+		"Docker is not creating the container in a timely manner. Will wait up to 30 seconds."
+			.to_owned(),
+		Some(body),
+		None,
+		false,
+	)
+	.await
+	.wrap_err("Failed to create the docker container")?;
+
+	Ok(())
+}
+
+/// Ensure the docker container exists.
+///
+/// # Errors
+///
+/// If we cannot talk to the docker socket, or there is a conflict creating the container.
+pub async fn ensure_docker_container(
+	client: &HttpClient,
+	project_root: &str,
+	tmp_dir: &str,
+	container: &DockerContainerInfo,
+) -> Result<()> {
+	let image_exists_url = format!("/images/{}/json", container.get_image());
+	let image_exists = docker_api_get(
+		client,
+		&image_exists_url,
+		"Taking awhile to query if image is downloaded from docker. Will wait up to 30 seconds."
+			.to_owned(),
+		None,
+		false,
+	)
+	.await
+	.wrap_err("Failed to check if image has downloaded.")
+	.is_ok();
+
+	if !image_exists {
+		download_image(client, container.get_image()).await?;
+	}
+	let (container_exists, container_running) =
+		is_container_created_and_running(client, container.get_container_name()).await?;
+
+	if !container_exists {
+		create_container(client, project_root, tmp_dir, container).await?;
+	}
+
+	if !container_running {
+		let url = format!("/containers/{}/start", container.get_container_name());
+		let _ = docker_api_post(
+			client,
+			&url,
+			"Docker is taking awhile to start the container. Will wait up to 30 seconds."
+				.to_owned(),
+			None,
+			None,
+			false,
+		)
+		.await
+		.wrap_err("Failed to tell docker to start running the Docker container")?;
+	}
+
+	let execution_id = execute_command_in_container(
+		client,
+		container.get_container_name(),
+		&[
+			"/usr/bin/env".to_owned(),
+			"bash".to_owned(),
+			"-c".to_owned(),
+			"hash bash".to_owned(),
+		],
+		&[],
+		container.get_base_user(),
+		false,
+		None,
+		None,
+	)
+	.await
+	.wrap_err("Failed to check for existance of bash in Docker container")?;
+
+	let has_bash = get_command_exit_code(client, &execution_id).await?;
+	if has_bash != 0 {
+		return Err(eyre!(
+			"Docker Image: [{}] does not have bash! This is required for dev-loop!",
+			container.get_image(),
+		))
+		.note(format!(
+			"To replicate you can run: `docker run --rm -it {} /usr/bin/env bash -c \"hash bash\"`",
+			container.get_image()
+		))
+		.note(format!(
+			"The container is also still running with the name: [{}]",
+			container.get_container_name()
+		));
+	}
+
+	setup_permission_helper(client, container).await?;
+
+	Ok(())
+}

--- a/src/executors/docker_engine/execution_api.rs
+++ b/src/executors/docker_engine/execution_api.rs
@@ -1,0 +1,182 @@
+use super::{docker_api_get, docker_api_post};
+
+use color_eyre::{
+	eyre::{eyre, WrapErr},
+	Result, Section,
+};
+use isahc::HttpClient;
+use std::{convert::TryFrom, time::Duration};
+
+/// Execute a command, and return the "execution id" to check back on it.
+///
+/// # Errors
+///
+/// Errors if we fail to create an exec instance with docker.
+#[allow(clippy::too_many_arguments)]
+pub async fn execute_command_in_container_async(
+	client: &HttpClient,
+	container_name: &str,
+	command: &[String],
+	environment_to_export: &[String],
+	user: &str,
+	needs_forced_ids: bool,
+	force_user_id: Option<u32>,
+	force_group_id: Option<u32>,
+) -> Result<String> {
+	let url = format!("/containers/{}/exec", container_name);
+	let body = if needs_forced_ids && (force_user_id.is_some() && force_group_id.is_some()) {
+		serde_json::json!({
+			"AttachStdout": true,
+			"AttachStderr": true,
+			"Tty": false,
+			"User": &format!("{}:{}", force_user_id.unwrap(), force_group_id.unwrap()),
+			"Privileged": true,
+			"Cmd": command,
+			"Env": environment_to_export,
+		})
+	} else {
+		serde_json::json!({
+			"AttachStdout": true,
+			"AttachStderr": true,
+			"Tty": false,
+			"User": user,
+			"Privileged": true,
+			"Cmd": command,
+			"Env": environment_to_export,
+		})
+	};
+
+	let resp = docker_api_post(
+		client,
+		&url,
+		"Docker is taking awhile to start running a new command. Will wait up to 30 seconds."
+			.to_owned(),
+		Some(body),
+		None,
+		true,
+	)
+	.await
+	.wrap_err("Failed to send new command to Docker container")?;
+
+	let potential_id = &resp["Id"];
+	if !potential_id.is_string() {
+		return Err(eyre!(
+			"Failed to find \"Id\" in response from docker: [{:?}]",
+			resp,
+		));
+	}
+	let exec_id = potential_id.as_str().unwrap().to_owned();
+
+	let start_url = format!("/exec/{}/start", &exec_id);
+	let start_body = serde_json::json!({
+		"Detach": true,
+		"Tty": false,
+	});
+
+	let _ = docker_api_post(
+		client,
+		&start_url,
+		"Docker is taking awhile to start running a new command. Will wait up to 30 seconds."
+			.to_owned(),
+		Some(start_body),
+		None,
+		false,
+	)
+	.await
+	.wrap_err("Failed to tell Docker container to start executing command")?;
+
+	Ok(exec_id)
+}
+
+/// Determine if a particular execution ID has finished executing.
+pub async fn has_command_finished(client: &HttpClient, execution_id: &str) -> bool {
+	let url = format!("/exec/{}/json", execution_id);
+	let resp_res = docker_api_get(
+		client,
+		&url,
+		"Taking awhile to determine if command has finished running in docker. Will wait up to 30 seconds.".to_owned(),
+		None,
+		true
+	).await;
+	if resp_res.is_err() {
+		return false;
+	}
+	let resp = resp_res.unwrap();
+	let is_running_opt = &resp["Running"];
+	if !is_running_opt.is_boolean() {
+		return false;
+	}
+
+	!is_running_opt.as_bool().unwrap()
+}
+
+/// Execute a raw command, and wait til it's finished. Returns execution id so you can checkup on it.
+///
+/// # Errors
+///
+/// Errors if we cannot talk to docker to create an exec instance.
+#[allow(clippy::too_many_arguments)]
+pub async fn execute_command_in_container(
+	client: &HttpClient,
+	container_name: &str,
+	command: &[String],
+	environment_to_export: &[String],
+	user: &str,
+	needs_forced_ids: bool,
+	force_user_id: Option<u32>,
+	force_group_id: Option<u32>,
+) -> Result<String> {
+	let execution_id = execute_command_in_container_async(
+		client,
+		container_name,
+		command,
+		environment_to_export,
+		user,
+		needs_forced_ids,
+		force_user_id,
+		force_group_id,
+	)
+	.await?;
+
+	loop {
+		if has_command_finished(client, &execution_id).await {
+			break;
+		}
+
+		async_std::task::sleep(Duration::from_micros(10)).await;
+	}
+
+	Ok(execution_id)
+}
+
+/// Get the exit code for a particular execution
+///
+/// # Errors
+///
+/// If we cannot find an `ExitCode` in the docker response, or talk to the docker socket.
+pub async fn get_command_exit_code(client: &HttpClient, execution_id: &str) -> Result<i32> {
+	let url = format!("/exec/{}/json", execution_id);
+	let resp = docker_api_get(
+		client,
+		&url,
+		"Taking awhile to query exit code of command from docker. Will wait up to 30 seconds."
+			.to_owned(),
+		None,
+		true,
+	)
+	.await
+	.wrap_err("Failed to query exit code from Docker")?;
+	let exit_code_opt = &resp["ExitCode"];
+	if !exit_code_opt.is_i64() {
+		return Err(eyre!(
+			"Failed to find integer ExitCode in response: [{:?}]",
+			resp,
+		))
+		.wrap_err("Failure querying exit code")
+		.suggestion("This is an internal error, please file an issue.");
+	}
+
+	Ok(i32::try_from(exit_code_opt.as_i64().unwrap())
+		.ok()
+		.unwrap_or(255))
+}

--- a/src/executors/docker_engine/image_api.rs
+++ b/src/executors/docker_engine/image_api.rs
@@ -1,0 +1,39 @@
+use super::docker_api_post;
+
+use color_eyre::{eyre::WrapErr, Result};
+use isahc::HttpClient;
+use std::time::Duration;
+
+/// Download the Image for this docker executor.
+///
+/// # Errors
+///
+/// Errors when it the docker api cannot be talked too, or the image cannot be downloaded.
+pub async fn download_image(client: &HttpClient, image: &str) -> Result<()> {
+	let image_tag_split = image.rsplitn(2, ':').collect::<Vec<&str>>();
+	let (image_name, tag_name) = if image_tag_split.len() == 2 {
+		(image_tag_split[1], image_tag_split[0])
+	} else {
+		(image_tag_split[0], "latest")
+	};
+	let url = format!("/images/create?fromImage={}&tag={}", image_name, tag_name);
+
+	let _ = docker_api_post(
+		client,
+		&url,
+		format!(
+			"Downloading the docker_image: [{}:{}]",
+			image_name, tag_name
+		),
+		None,
+		Some(Duration::from_secs(3600)),
+		false,
+	)
+	.await
+	.wrap_err(format!(
+		"Failed to download image: [{}:{}]",
+		image_name, tag_name
+	))?;
+
+	Ok(())
+}

--- a/src/executors/docker_engine/mod.rs
+++ b/src/executors/docker_engine/mod.rs
@@ -1,0 +1,223 @@
+//! Represents interacting with the Docker Engine API.
+
+use crate::future_helper::timeout_with_log_msg;
+
+use color_eyre::{
+	eyre::{eyre, WrapErr},
+	Result, Section,
+};
+use isahc::{http::request::Request, prelude::*, Body, HttpClient};
+use once_cell::sync::Lazy;
+use serde_json::Value as JsonValue;
+use std::time::Duration;
+use tracing::debug;
+
+/// This is the api version we use for talking to the docker socket.
+///
+/// The docker socket allows us to choose a versioned api like this, which is
+/// why we use it as opposed to using a terminal command (not to mention we
+/// don't have to worry about escaping correctly).
+///
+/// `v1.40` is chosen because as of the time of writing this
+/// `v1.40` is the version for Docker Engine 19.03, which at
+/// the time of writing this (July 3rd, 2020) is the lowest supported
+/// version according to docker:
+///
+/// <https://success.docker.com/article/compatibility-matrix>
+///
+/// We can bump this in the future when we know it won't run into anyone.
+const DOCKER_API_VERSION: &str = "/v1.40";
+const DOCKER_STATUS_CODES_ERR_NOTE: &str = "To find out what the status code means you can check the Docker documentation: https://docs.docker.com/engine/api/v1.40/.";
+
+cfg_if::cfg_if! {
+  if #[cfg(unix)] {
+		pub const SOCKET_PATH: &str = "/var/run/docker.sock";
+  } else if #[cfg(win)] {
+		// TODO(xxx): named pipes? url?
+		pub const SOCKET_PATH: &str = "UNIMPLEMENTED";
+  }
+}
+
+// A global lock for the unix socket since it can't have multiple things communicating
+// at the same time.
+//
+// You can techincally have multiple writers on windows but only up to a particular buff
+// size, and it's just much easier to have just a global lock, and take the extra bit. Really
+// the only time this is truly slow is when we're downloading a docker image.
+static DOCK_SOCK_LOCK: Lazy<async_std::sync::Mutex<()>> =
+	Lazy::new(|| async_std::sync::Mutex::new(()));
+
+async fn docker_api_call<B: Into<Body>>(
+	client: &HttpClient,
+	req: Request<B>,
+	long_call_msg: String,
+	timeout: Option<Duration>,
+	is_json: bool,
+) -> Result<JsonValue> {
+	let _guard = DOCK_SOCK_LOCK.lock().await;
+	let uri = req.uri().to_string();
+
+	let log_timeout = Duration::from_secs(3);
+	let timeout_frd = timeout.unwrap_or_else(|| Duration::from_secs(30));
+	let mut resp = timeout_with_log_msg(
+		long_call_msg,
+		log_timeout,
+		timeout_frd,
+		client.send_async(req),
+	)
+	.await??;
+
+	let status = resp.status().as_u16();
+	if status < 200 || status > 299 {
+		return Err(eyre!(
+			"Docker responded with a status code: [{}] which is not in the 200-300 range.",
+			status,
+		))
+		.note(DOCKER_STATUS_CODES_ERR_NOTE)
+		.context(uri);
+	}
+
+	if is_json {
+		Ok(resp
+			.json()
+			.wrap_err("Failure to response Docker response as JSON")
+			.context(uri)?)
+	} else {
+		// Ensure the response body is read in it's entirerty. Otherwise
+		// the body could still be writing, but we think we're done with the
+		// request, and all of a sudden we're writing to a socket while
+		// a response body is all being written and it's all bad.
+		let _ = resp.text();
+		Ok(serde_json::Value::default())
+	}
+}
+
+/// Call the docker engine api using the GET http method.
+///
+/// `client`: the http client to use.
+/// `path`: the path to call (along with Query Args).
+/// `long_call_msg`: the message to print when docker is taking awhile to respond.
+/// `timeout`: The optional timeout. Defaults to 30 seconds.
+/// `is_json`: whether or not to parse the response as json.
+pub(self) async fn docker_api_get(
+	client: &HttpClient,
+	path: &str,
+	long_call_msg: String,
+	timeout: Option<Duration>,
+	is_json: bool,
+) -> Result<JsonValue> {
+	let url = format!("http://localhost{}{}", DOCKER_API_VERSION, path);
+	debug!("URL for get will be: {}", url);
+	let req = Request::get(url)
+		.header("Accept", "application/json; charset=UTF-8")
+		.header("Content-Type", "application/json; charset=UTF-8")
+		.body(())
+		.wrap_err("Internal-Error: Failed to construct http request.")
+		.suggestion("Please report this as an issue so it can be fixed.")?;
+
+	docker_api_call(client, req, long_call_msg, timeout, is_json)
+		.await
+		.context(format!("URL: {}", path))
+}
+
+/// Call the docker engine api using the POST http method.
+///
+/// `client`: the http client to use.
+/// `path`: the path to call (along with Query Args).
+/// `long_call_msg`: the message to print when docker is taking awhile to respond.
+/// `body`: The body to send to the remote endpoint.
+/// `timeout`: the optional timeout. Defaults to 30 seconds.
+/// `is_json`: whether to attempt to read the response body as json.
+pub(self) async fn docker_api_post(
+	client: &HttpClient,
+	path: &str,
+	long_call_msg: String,
+	body: Option<serde_json::Value>,
+	timeout: Option<Duration>,
+	is_json: bool,
+) -> Result<JsonValue> {
+	let url = format!("http://localhost{}{}", DOCKER_API_VERSION, path);
+	debug!("URL for post will be: {}", url);
+	let req_part = Request::post(url)
+		.header("Accept", "application/json; charset=UTF-8")
+		.header("Content-Type", "application/json; charset=UTF-8")
+		.header("Expect", "");
+	let req = if let Some(body_data) = body {
+		req_part
+			.body(
+				serde_json::to_vec(&body_data)
+					.wrap_err("Failure converting HTTP Request Body to JSON")
+					.suggestion("This is an internal error, please report this issue.")?,
+			)
+			.wrap_err("Failed to write body to request")
+			.suggestion("This is an internal error, please report this issue.")?
+	} else {
+		req_part
+			.body(Vec::new())
+			.wrap_err("Failed to write body to request")
+			.suggestion("This is an internal error, please report this issue.")?
+	};
+
+	docker_api_call(client, req, long_call_msg, timeout, is_json)
+		.await
+		.context(format!("URL: {}", path))
+}
+
+/// Call the docker engine api using the POST http method.
+///
+/// `client`: the http client to use.
+/// `path`: the path to call (along with Query Args).
+/// `long_call_msg`: the message to print when docker is taking awhile to respond.
+/// `body`: The body to send to the remote endpoint.
+/// `timeout`: the timeout for this requests, defaults to 30 seconds.
+/// `is_json`: whether to actually try to read the response body as json.
+pub(self) async fn docker_api_delete(
+	client: &HttpClient,
+	path: &str,
+	long_call_msg: String,
+	body: Option<serde_json::Value>,
+	timeout: Option<Duration>,
+	is_json: bool,
+) -> Result<JsonValue> {
+	let url = format!("http://localhost{}{}", DOCKER_API_VERSION, path);
+	debug!("URL for delete will be: {}", url);
+	let req_part = Request::delete(url)
+		.header("Accept", "application/json; charset=UTF-8")
+		.header("Content-Type", "application/json; charset=UTF-8")
+		.header("Expect", "");
+	let req = if let Some(body_data) = body {
+		req_part
+			.body(
+				serde_json::to_vec(&body_data)
+					.wrap_err("Failure converting HTTP Request Body to JSON")
+					.suggestion("This is an internal error, please report this issue.")?,
+			)
+			.wrap_err("Failed to write body to request")
+			.suggestion("This is an internal error, please report this issue.")?
+	} else {
+		req_part
+			.body(Vec::new())
+			.wrap_err("Failed to write body to request")
+			.suggestion("This is an internal error, please report this issue.")?
+	};
+
+	docker_api_call(client, req, long_call_msg, timeout, is_json)
+		.await
+		.context(format!("URL: {}", path))
+}
+
+pub(crate) mod container;
+pub(crate) mod container_api;
+pub(crate) mod execution_api;
+pub(crate) mod image_api;
+pub(crate) mod network_api;
+pub(crate) mod permissions_helper;
+pub(crate) mod version_api;
+
+pub use container::*;
+pub use container_api::*;
+pub use execution_api::*;
+pub use image_api::*;
+pub use network_api::*;
+pub use permissions_helper::*;
+pub use version_api::*;

--- a/src/executors/docker_engine/network_api.rs
+++ b/src/executors/docker_engine/network_api.rs
@@ -1,0 +1,182 @@
+use super::{docker_api_delete, docker_api_get, docker_api_post};
+
+use color_eyre::{eyre::WrapErr, Result, Section};
+use isahc::HttpClient;
+use tracing::error;
+
+pub async fn list_devloop_networks(client: &HttpClient) -> Result<Vec<String>> {
+	let json_networks = docker_api_get(
+		&client,
+		"/networks",
+		"Taking ahwile to query networks from docker. Will wait up til 30 seconds.".to_owned(),
+		None,
+		true,
+	)
+	.await?;
+
+	let mut devloop_networks = Vec::new();
+	if let Some(networks) = json_networks.as_array() {
+		for network in networks {
+			if let Some(name_untyped) = network.get("Name") {
+				if let Some(name_str) = name_untyped.as_str() {
+					if name_str.starts_with("dl-") {
+						devloop_networks.push(name_str.to_owned());
+					}
+				}
+			}
+		}
+	}
+
+	Ok(devloop_networks)
+}
+
+pub async fn delete_network(client: &HttpClient, network: &str) {
+	let err = docker_api_delete(
+		&client,
+		&format!("/networks/{}", network),
+		"Docker is taking awhile to delete a docker network. Will wait up to 30 seconds."
+			.to_owned(),
+		None,
+		None,
+		false,
+	)
+	.await;
+
+	if err.is_err() {
+		error!(
+			"{:?}",
+			err.wrap_err(format!("Failed to delete docker network: [{}]", network))
+				.suggestion(format!(
+					"You can try deleting the network manually with: `docker network rm {}`",
+					network
+				))
+				.unwrap_err(),
+		);
+	}
+}
+
+/// Ensure a particular network exists.
+///
+/// # Errors
+///
+/// If we cannot talk to the docker socket, or there is an error creating the network.
+pub async fn ensure_network_exists(client: &HttpClient, pipeline_id: &str) -> Result<()> {
+	let network_id = format!("dl-{}", pipeline_id);
+	let network_url = format!("/networks/{}", network_id);
+	let res = docker_api_get(
+		client,
+		&network_url,
+		"Taking awhile to query network existance status from docker. Will wait up to 30 seconds."
+			.to_owned(),
+		None,
+		true,
+	)
+	.await
+	.wrap_err(format!(
+		"Failed to query network information: {}",
+		network_id
+	));
+
+	if res.is_err() {
+		let json_body = serde_json::json!({
+			"Name": network_id,
+		});
+
+		let _ = docker_api_post(
+			client,
+			"/networks/create",
+			"Docker is not creating the network in a timely manner. Will wait up to 30 seconds."
+				.to_owned(),
+			Some(json_body),
+			None,
+			false,
+		)
+		.await
+		.wrap_err(format!("Failed to create docker network: {}", network_id))?;
+	}
+
+	Ok(())
+}
+
+/// Determine if the container is attached to a particular network.
+///
+/// If there were any errors we'll just return false.
+pub async fn is_network_attached(
+	client: &HttpClient,
+	container_name: &str,
+	pipeline_id: &str,
+) -> bool {
+	let url = format!("/containers/{}/json", container_name);
+	let body_res = docker_api_get(
+		&client,
+		&url,
+		"Taking awhile to get container status from docker. Will wait up to 30 seconds.".to_owned(),
+		None,
+		true,
+	)
+	.await;
+	if body_res.is_err() {
+		return false;
+	}
+	let body = body_res.unwrap();
+	let id_as_opt = body["Id"].as_str();
+	if id_as_opt.is_none() {
+		return false;
+	}
+	let id = id_as_opt.unwrap();
+
+	let network_url = format!("/networks/dl-{}", pipeline_id);
+	let network_body_res = docker_api_get(
+		client,
+		&network_url,
+		"Taking awhile to get network status from docker. Will wait up to 30 seconds.".to_owned(),
+		None,
+		true,
+	)
+	.await;
+	if network_body_res.is_err() {
+		return false;
+	}
+	let network_body = network_body_res.unwrap();
+	let networks_obj_opt = network_body["Containers"].as_object();
+	if networks_obj_opt.is_none() {
+		return false;
+	}
+	let networks_obj = networks_obj_opt.unwrap();
+
+	networks_obj.contains_key(id)
+}
+
+/// Ensure a particular network has been attached to this container.
+///
+/// # Errors
+///
+/// If we fail to talk to the docker socket, or connect the container to the network.
+pub async fn ensure_network_attached(
+	client: &HttpClient,
+	container_name: &str,
+	hostname: &str,
+	pipeline_id: &str,
+) -> Result<()> {
+	if !is_network_attached(client, container_name, pipeline_id).await {
+		let url = format!("/networks/dl-{}/connect", pipeline_id);
+		let body = serde_json::json!({
+			"Container": container_name,
+			"EndpointConfig": {
+				"Aliases": [hostname],
+			}
+		});
+
+		let _ = docker_api_post(
+			client,
+			&url,
+			"Docker is taking awhile to attach a network to the container. Will wait up to 30 seconds.".to_owned(),
+			Some(body),
+			None,
+			false
+		).await
+		 .wrap_err("Failed to attach network to Docker Container.")?;
+	}
+
+	Ok(())
+}

--- a/src/executors/docker_engine/permissions_helper.rs
+++ b/src/executors/docker_engine/permissions_helper.rs
@@ -1,0 +1,245 @@
+use super::{execute_command_in_container, get_command_exit_code, DockerContainerInfo};
+
+use color_eyre::{
+	eyre::{eyre, WrapErr},
+	Result, Section,
+};
+use isahc::HttpClient;
+use once_cell::sync::Lazy;
+
+static DOCK_USER_LOCK: Lazy<async_std::sync::Mutex<()>> =
+	Lazy::new(|| async_std::sync::Mutex::new(()));
+const _PERMISSIONS_HELPER_EXPERIMENTAL_SUGGESTION: &str = "The permissions helper is still experimental. Please report this so it can be fixed before stabilization.";
+
+/// Setup the permission helper for this docker container if it's been configured.
+///
+/// # Errors
+///
+/// If we cannot talk to the docker socket, or cannot create the user.
+pub async fn setup_permission_helper(
+	client: &HttpClient,
+	container: &DockerContainerInfo,
+) -> Result<()> {
+	let _guard = DOCK_USER_LOCK.lock().await;
+	if container.get_proxy_user_id().is_none() || container.get_proxy_group_id().is_none() {
+		return Ok(());
+	}
+
+	let forced_user_id = container.get_proxy_user_id().unwrap();
+	let forced_group_id = container.get_proxy_group_id().unwrap();
+	let has_sudo = container_has_sudo(
+		client,
+		container.get_container_name(),
+		container.get_base_user(),
+	)
+	.await
+	.suggestion(_PERMISSIONS_HELPER_EXPERIMENTAL_SUGGESTION)?;
+	if has_created_proxy_user_before(
+		client,
+		container.get_container_name(),
+		container.get_base_user(),
+	)
+	.await
+	.suggestion(_PERMISSIONS_HELPER_EXPERIMENTAL_SUGGESTION)?
+	{
+		return Ok(());
+	}
+	create_permissions_proxy_user(
+		client,
+		container.get_container_name(),
+		container.get_base_user(),
+		*forced_user_id,
+		*forced_group_id,
+		has_sudo,
+	)
+	.await
+	.suggestion(_PERMISSIONS_HELPER_EXPERIMENTAL_SUGGESTION)?;
+
+	// Allow the user to sudo, if sudo is installed.
+	if has_sudo {
+		allow_proxy_user_to_sudo(
+			client,
+			container.get_container_name(),
+			container.get_base_user(),
+		)
+		.await
+		.suggestion(_PERMISSIONS_HELPER_EXPERIMENTAL_SUGGESTION)?;
+	}
+
+	Ok(())
+}
+
+/// Perform a very simple execute and wait for command to finish.
+async fn execute_and_wait_simple(
+	client: &HttpClient,
+	container_name: &str,
+	user: &str,
+	command: &[String],
+) -> Result<String> {
+	execute_command_in_container(
+		client,
+		container_name,
+		command,
+		&[],
+		user,
+		false,
+		None,
+		None,
+	)
+	.await
+}
+
+/// Check if a container has sudo installed.
+async fn container_has_sudo(client: &HttpClient, container_name: &str, user: &str) -> Result<bool> {
+	let sudo_execution_id = execute_and_wait_simple(
+		client,
+		container_name,
+		user,
+		&[
+			"/usr/bin/env".to_owned(),
+			"bash".to_owned(),
+			"-c".to_owned(),
+			"hash sudo".to_owned(),
+		],
+	)
+	.await
+	.wrap_err(
+		"Failure Checking for sudo existance inside docker container for permissions helper.",
+	)?;
+
+	Ok(get_command_exit_code(client, &sudo_execution_id)
+		.await
+		.wrap_err(
+			"Failure Checking for sudo existance inside docker container for permissions helper.",
+		)? == 0)
+}
+
+/// Check if this user has already created the dev-loop permissions helper user.
+async fn has_created_proxy_user_before(
+	client: &HttpClient,
+	container_name: &str,
+	user: &str,
+) -> Result<bool> {
+	let user_exist_id = execute_and_wait_simple(
+		client,
+		container_name,
+		user,
+		&[
+			"/usr/bin/env".to_owned(),
+			"bash".to_owned(),
+			"-c".to_owned(),
+			"getent passwd dl".to_owned(),
+		],
+	)
+	.await
+	.wrap_err("Failure checking if user has already been created for permissions helper.")?;
+
+	if get_command_exit_code(client, &user_exist_id)
+		.await
+		.wrap_err("Failure checking if user has already been created for permissions helper.")?
+		== 0
+	{
+		Ok(true)
+	} else {
+		Ok(false)
+	}
+}
+
+/// Create a user in the docker container that has the same user id/group id
+/// as the user on the host so we can proxy permissions.
+async fn create_permissions_proxy_user(
+	client: &HttpClient,
+	container_name: &str,
+	user: &str,
+	forced_user_id: u32,
+	forced_group_id: u32,
+	has_sudo: bool,
+) -> Result<()> {
+	let creation_execution_id = match (user == "root", has_sudo) {
+		(true, _) | (false, false) => execute_and_wait_simple(
+			client,
+			container_name,
+			user,
+			&[
+				"/usr/bin/env".to_owned(),
+				"bash".to_owned(),
+				"-c".to_owned(),
+				format!(
+					"groupadd -g {} -o dl && useradd -u {} -g {} -o -c '' -m dl",
+					forced_group_id, forced_user_id, forced_group_id
+				),
+			],
+		)
+		.await
+		.wrap_err("Failure creating user for permissions helper")?,
+		(false, true) => execute_and_wait_simple(
+			client,
+			container_name,
+			user,
+			&[
+				"/usr/bin/env".to_owned(),
+				"bash".to_owned(),
+				"-c".to_owned(),
+				format!(
+					"sudo -n groupadd -g {} -o dl && sudo -n useradd -u {} -g {} -o -c '' -m dl",
+					forced_group_id, forced_user_id, forced_group_id
+				),
+			],
+		)
+		.await
+		.wrap_err("Failure creating user for permissions helper")?,
+	};
+
+	if get_command_exit_code(client, &creation_execution_id).await? != 0 {
+		return Err(eyre!(
+			"Failed to get successful ExitCode from docker on user creation for permissions helper"
+		));
+	}
+
+	Ok(())
+}
+
+/// Allow the permissions proxy user to sudo.
+async fn allow_proxy_user_to_sudo(
+	client: &HttpClient,
+	container_name: &str,
+	user: &str,
+) -> Result<()> {
+	let sudo_user_creation_id = if user == "root" {
+		execute_and_wait_simple(
+      client,
+  container_name,
+  user,
+  &[
+      "/usr/bin/env".to_owned(),
+      "bash".to_owned(),
+      "-c".to_owned(),
+      "mkdir -p /etc/sudoers.d && echo \"dl ALL=(root) NOPASSWD:ALL\" > /etc/sudoers.d/dl && chmod 0440 /etc/sudoers.d/dl".to_owned()
+    ],
+    ).await.wrap_err("Failure adding user to sudoers for permissions helper")?
+	} else {
+		execute_and_wait_simple(
+      client,
+      container_name,
+      user,
+      &[
+        "/usr/bin/env".to_owned(),
+        "bash".to_owned(),
+        "-c".to_owned(),
+        "sudo -n mkdir -p /etc/sudoers.d && echo \"dl ALL=(root) NOPASSWD:ALL\" | sudo -n tee /etc/sudoers.d/dl && sudo -n chmod 0440 /etc/sudoers.d/dl".to_owned()
+      ],
+    ).await.wrap_err("Failure adding user to sudoers for permissions helper")?
+	};
+
+	if get_command_exit_code(client, &sudo_user_creation_id)
+		.await
+		.wrap_err("Failure adding user to sudoers for permissions helper.")?
+		!= 0
+	{
+		return Err(eyre!(
+			"Failed to setup passwordless sudo access for permissions helper!"
+		));
+	}
+
+	Ok(())
+}

--- a/src/executors/docker_engine/version_api.rs
+++ b/src/executors/docker_engine/version_api.rs
@@ -1,0 +1,16 @@
+use super::docker_api_get;
+
+use color_eyre::Result;
+use isahc::HttpClient;
+use serde_json::Value as JsonValue;
+
+pub async fn docker_version_check(client: &HttpClient) -> Result<JsonValue> {
+	docker_api_get(
+		client,
+		"/version",
+		"Taking awhile to query version from docker. Will wait up to 30 seconds.".to_owned(),
+		None,
+		true,
+	)
+	.await
+}

--- a/src/executors/shared.rs
+++ b/src/executors/shared.rs
@@ -1,0 +1,132 @@
+use crate::{
+	dirs::{get_tmp_dir, mark_as_world_editable, mark_file_as_executable, rewrite_tmp_dir},
+	executors::ExecutableTask,
+};
+
+use color_eyre::{eyre::WrapErr, Result, Section};
+use std::{
+	fs::{create_dir_all, write as write_file, File},
+	path::PathBuf,
+	time::{SystemTime, UNIX_EPOCH},
+};
+use tracing::warn;
+
+/// Create the shared directory to execute in.
+pub fn create_executor_shared_dir(pipeline_id: &str) -> Result<PathBuf> {
+	let mut tmp_path = get_tmp_dir();
+	tmp_path.push(format!("{}-dl-host", pipeline_id));
+	create_dir_all(tmp_path.clone())?;
+	Ok(tmp_path)
+}
+
+/// Create a series of files that can be used to capture logs for an entrypoint.
+pub fn create_log_proxy_files(
+	shared_dir: &PathBuf,
+	task: &ExecutableTask,
+) -> Result<(PathBuf, PathBuf)> {
+	let epoch = SystemTime::now()
+		.duration_since(UNIX_EPOCH)
+		.wrap_err(
+			"System Clock is before unix start time? Please make sure your clock is accurate.",
+		)?
+		.as_secs();
+
+	let mut stdout_log_path = shared_dir.clone();
+	stdout_log_path.push(format!("{}-{}-out.log", epoch, task.get_task_name()));
+	let mut stderr_log_path = shared_dir.clone();
+	stderr_log_path.push(format!("{}-{}-err.log", epoch, task.get_task_name()));
+
+	File::create(&stdout_log_path)
+		.wrap_err("Failed to create file for logs to stdout")
+		.note("If the issue isn't immediately clear (e.g. disk full), please file an issue.")?;
+	File::create(&stderr_log_path)
+		.wrap_err("Failed to create file for logs to stderr")
+		.note("If the issue isn't immediately clear (e.g. disk full), please file an issue.")?;
+
+	if let Err(err) = mark_as_world_editable(&stdout_log_path) {
+		warn!("NOTE Failed to mark stdout log file: [{:?}] as world writable, this may cause a lack of logs to be written.\n{:?}", stdout_log_path, err);
+	}
+	if let Err(err) = mark_as_world_editable(&stderr_log_path) {
+		warn!("NOTE Failed to mark stderr log file: [{:?}] as world writable, this may cause a lack of logs to be written.\n{:?}", stderr_log_path, err);
+	}
+
+	Ok((stdout_log_path, stderr_log_path))
+}
+
+/// Create an entrypoint to run for tasks.
+#[allow(clippy::too_many_arguments)]
+pub fn create_entrypoint(
+	project_root: &str,
+	tmp_dir: &str,
+	shared_dir: PathBuf,
+	helper_src_line: &str,
+	task: &ExecutableTask,
+	rewrite_tmp: bool,
+	stdout_log_path: Option<String>,
+	stderr_log_path: Option<String>,
+) -> Result<PathBuf> {
+	let mut task_path = shared_dir.clone();
+	task_path.push(format!("{}.sh", task.get_task_name()));
+
+	let script_to_run = if rewrite_tmp {
+		rewrite_tmp_dir(tmp_dir, &task_path)
+	} else {
+		task_path.to_string_lossy().to_string()
+	};
+
+	let mut entrypoint_path = shared_dir;
+	entrypoint_path.push(format!("{}-entrypoint.sh", task.get_task_name()));
+
+	write_file(&task_path, task.get_contents().get_contents())
+		.wrap_err("Failed to copy your task script to temporary directory")?;
+
+	let mut entrypoint_script = format!(
+		"#!/usr/bin/env bash
+
+{opening_bracket}
+
+cd {project_root}
+
+# Source Helpers
+{helper}
+
+eval \"$(declare -F | sed -e 's/-f /-fx /')\"
+
+{script} {arg_str}
+
+{closing_bracket}",
+		opening_bracket = "{",
+		project_root = project_root,
+		helper = helper_src_line,
+		script = script_to_run,
+		arg_str = task.get_arg_string(),
+		closing_bracket = "}",
+	);
+	match (stdout_log_path.is_some(), stderr_log_path.is_some()) {
+		(true, true) => {
+			entrypoint_script += &format!(
+				" >{} 2>{}",
+				stdout_log_path.unwrap(),
+				stderr_log_path.unwrap()
+			);
+		}
+		(true, false) => {
+			entrypoint_script += &format!(" >{}", stdout_log_path.unwrap());
+		}
+		(false, true) => {
+			entrypoint_script += &format!(" 2>{}", stderr_log_path.unwrap());
+		}
+		(false, false) => {}
+	}
+
+	write_file(&entrypoint_path, entrypoint_script).wrap_err("Failed to write entrypoint file")?;
+
+	mark_file_as_executable(&task_path)?;
+	mark_file_as_executable(&entrypoint_path)?;
+
+	if rewrite_tmp {
+		Ok(entrypoint_path)
+	} else {
+		Ok(PathBuf::from(rewrite_tmp_dir(tmp_dir, &entrypoint_path)))
+	}
+}

--- a/src/fetch/fs.rs
+++ b/src/fetch/fs.rs
@@ -83,11 +83,7 @@ fn read_path_as_item_blocking(file: &PathBuf, project_root: &PathBuf) -> Result<
 	let mut contents = Vec::new();
 	fh.read_to_end(&mut contents)?;
 
-	Ok(FetchedItem::new(
-		contents,
-		LocationType::Path,
-		source_location,
-	))
+	Ok(FetchedItem::new(contents, source_location))
 }
 
 /// Handles all fetching based on the 'path' directive.

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -18,8 +18,6 @@ use std::{
 pub struct FetchedItem {
 	/// The contents of whatever was fetched.
 	contents: Vec<u8>,
-	/// The fetcher that fetched this item.
-	fetched_by: LocationType,
 	/// An end-user understood idea of where this item came from.
 	source: String,
 }
@@ -31,24 +29,14 @@ impl FetchedItem {
 	/// `fetched_by`: The fetcher that fetched this task.
 	/// `source`: The source of where this came from.
 	#[must_use]
-	pub fn new(contents: Vec<u8>, fetched_by: LocationType, source: String) -> Self {
-		Self {
-			contents,
-			fetched_by,
-			source,
-		}
+	pub fn new(contents: Vec<u8>, source: String) -> Self {
+		Self { contents, source }
 	}
 
 	/// Get the contents of this fetched item.
 	#[must_use]
 	pub fn get_contents(&self) -> &[u8] {
 		&self.contents
-	}
-
-	/// Get who fetched this particular item.
-	#[must_use]
-	pub fn get_fetched_by(&self) -> &LocationType {
-		&self.fetched_by
 	}
 
 	/// Get the source location.
@@ -58,8 +46,8 @@ impl FetchedItem {
 	}
 }
 
-pub mod fs;
-pub mod remote;
+pub(crate) mod fs;
+pub(crate) mod remote;
 
 /// A wrapper around all the fetchers at once, so you just have one type to
 /// deal with.
@@ -90,23 +78,6 @@ impl FetcherRepository {
 			path_fetcher,
 			project_root,
 		})
-	}
-
-	/// Fetch from a particular location.
-	///
-	/// # Errors
-	///
-	/// - Bubbled error from underlying fetchers when there is an error fetching
-	///   the item.
-	pub async fn fetch(&self, location: &LocationConf) -> Result<Vec<FetchedItem>> {
-		match *location.get_type() {
-			LocationType::HTTP => self.http_fetcher.fetch_http(location).await,
-			LocationType::Path => {
-				self.path_fetcher
-					.fetch_from_fs(location, &self.project_root, &self.project_root, None)
-					.await
-			}
-		}
 	}
 
 	/// Fetch from a particular location, while filtering on filename.

--- a/src/fetch/remote.rs
+++ b/src/fetch/remote.rs
@@ -65,11 +65,7 @@ impl HttpFetcher {
 		let mut results = Vec::with_capacity(1);
 		let string = resp.text()?;
 		let bytes = Vec::from(string.as_bytes());
-		results.push(FetchedItem::new(
-			bytes,
-			LocationType::HTTP,
-			location.get_at().to_owned(),
-		));
+		results.push(FetchedItem::new(bytes, location.get_at().to_owned()));
 
 		Ok(results)
 	}

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,7 +1,7 @@
 //! Handles any logging utilities that we need in our crate for dev-loop.
 
 use color_eyre::{config::HookBuilder, Result};
-use lazy_static::*;
+use lazy_static::lazy_static;
 use std::sync::{
 	atomic::{AtomicBool, Ordering},
 	Arc,
@@ -17,7 +17,7 @@ use tracing_subscriber::{
 };
 
 lazy_static! {
-	pub static ref HAS_OUTPUT_LOG_MSG: Arc<AtomicBool> = Arc::new(AtomicBool::new(true));
+	pub static ref HAS_OUTPUT_LOG_MSG: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
 }
 
 struct TracingSubscriber {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,26 +1,20 @@
-#![allow(
-	clippy::module_name_repetitions,
-	clippy::result_map_unwrap_or_else,
-	clippy::wildcard_imports
-)]
-
 use crate::config::types::TopLevelConf;
 
 use color_eyre::{eyre::eyre, Report, Section};
 use tracing::warn;
 
-pub mod commands;
-pub mod config;
-pub mod dirs;
-pub mod executors;
-pub mod fetch;
-pub mod future_helper;
-pub mod log;
-pub mod sigint;
-pub mod strsim;
-pub mod tasks;
-pub mod terminal;
-pub mod yaml_err;
+pub(crate) mod commands;
+pub(crate) mod config;
+pub(crate) mod dirs;
+pub(crate) mod executors;
+pub(crate) mod fetch;
+pub(crate) mod future_helper;
+pub(crate) mod log;
+pub(crate) mod sigint;
+pub(crate) mod strsim;
+pub(crate) mod tasks;
+pub(crate) mod terminal;
+pub(crate) mod yaml_err;
 
 /// The entrypoint to the application.
 ///
@@ -51,7 +45,7 @@ fn main() -> Result<(), Report> {
 		action = "list".to_owned();
 	}
 
-	let tlc_res = config::get_top_level_config();
+	let tlc_res = config::get_top_level();
 	let errord_on_tlc = tlc_res.is_err();
 	let tlc = if let Err(tlc_err) = tlc_res {
 		// NOTE(cynthia): if you change this print statement, make sure it looks

--- a/src/sigint.rs
+++ b/src/sigint.rs
@@ -1,5 +1,5 @@
 use color_eyre::{eyre::WrapErr, Result, Section};
-use lazy_static::*;
+use lazy_static::lazy_static;
 
 lazy_static! {
 	pub static ref RUNNING: Arc<AtomicBool> = Arc::new(AtomicBool::new(true));

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -6,7 +6,7 @@ use crate::{
 	config::types::{LocationType, TaskConf, TaskConfFile, TaskType, TopLevelConf},
 	fetch::FetcherRepository,
 	strsim::add_did_you_mean_text,
-	yaml_err::contextualize_yaml_err,
+	yaml_err::contextualize,
 };
 
 use color_eyre::{
@@ -16,8 +16,8 @@ use color_eyre::{
 use std::collections::{HashMap, HashSet};
 use tracing::warn;
 
-pub mod execution;
-pub mod fs;
+pub(crate) mod execution;
+pub(crate) mod fs;
 
 /// Describes the full "graph" of tasks.
 ///
@@ -31,6 +31,75 @@ pub struct TaskGraph {
 }
 
 impl TaskGraph {
+	fn parse_task(
+		task_conf_file_src: &str,
+		task_conf: TaskConf,
+		internal_task_names: &mut HashSet<String>,
+		unsatisfied_task_names: &mut HashSet<String>,
+		flatenned_tasks: &mut HashMap<String, TaskConf>,
+	) -> Result<()> {
+		let task_name = task_conf.get_name();
+
+		// If we've already seen this task... it's an error.
+		// Task names need to be globally unique.
+		if let Some(other_task_conf) = flatenned_tasks.get(task_name) {
+			return Err(eyre!(
+				"Found duplicate task named: [{}]. Originally defined in config at: [{}], found again in config at: [{}]",
+				task_name,
+				other_task_conf.get_source_path(),
+				task_conf_file_src,
+			));
+		}
+
+		// If it's a 'oneof', 'parallel-pipeline', or 'pipeline' type, we
+		// need to parse it's children so we can ensure everything is valid.
+		//
+		// We call `internal_task_names.remove()` always (it'll be a no-op if it
+		// doesn't contain the key). The `internal_task_names` are tasks that are marked
+		// `internal: true`, but don't yet have a reference. By being in a
+		// oneof/parallel-pipeline/pipeline they themselves have a reference.
+		//
+		// Next we check if the option "exists", if not. we add it to `unsatisfied_task_names`
+		// so it can be checked later.
+		let ttype = task_conf.get_type();
+		match ttype {
+			TaskType::Oneof => {
+				if let Some(options) = task_conf.get_options() {
+					for option in options {
+						internal_task_names.remove(option.get_task_name());
+						if !flatenned_tasks.contains_key(option.get_task_name()) {
+							unsatisfied_task_names.insert(option.get_task_name().to_owned());
+						}
+					}
+				}
+			}
+			TaskType::Pipeline | TaskType::ParallelPipeline => {
+				if let Some(steps) = task_conf.get_steps() {
+					for step in steps {
+						internal_task_names.remove(step.get_task_name());
+						if !flatenned_tasks.contains_key(step.get_task_name()) {
+							unsatisfied_task_names.insert(step.get_task_name().to_owned());
+						}
+					}
+				}
+			}
+			TaskType::Command => {}
+		}
+
+		// If we're an internal task, and someone hasn't referenced us already
+		// go ahead and add ourselves to the list of "waiting for a ref" set.
+		if task_conf.is_internal() && !unsatisfied_task_names.contains(task_name) {
+			internal_task_names.insert(task_name.to_owned());
+		}
+		// NO-OP if we're not there, otherwise let people know we exist.
+		unsatisfied_task_names.remove(task_name);
+
+		// Add ourselves to the final map.
+		flatenned_tasks.insert(task_name.to_owned(), task_conf);
+
+		Ok(())
+	}
+
 	/// Create a new `TaskGraph`.
 	///
 	/// NOTE: this will completely parse all the task files (remote or otherwise),
@@ -44,7 +113,6 @@ impl TaskGraph {
 	/// - When there is an error fetching the tasks yaml files.
 	/// - When the task yaml files are invalid yaml.
 	/// - When the task yaml file has some sort of invariant error.
-	#[allow(clippy::cognitive_complexity, clippy::too_many_lines)]
 	pub async fn new(tlc: &TopLevelConf, fetcher: &FetcherRepository) -> Result<Self> {
 		let span = tracing::info_span!("finding_tasks");
 		let _guard = span.enter();
@@ -75,7 +143,7 @@ impl TaskGraph {
 					.await
 					.wrap_err(format!(
 						"Failed fetching tasks specified at `.dl/config.yml:task_locations:{}`",
-						tl_idx
+						tl_idx,
 					));
 
 				// For HTTP errors we're going to try to continue, if your FS fails
@@ -85,18 +153,17 @@ impl TaskGraph {
 						warn!("{:?}", err);
 						warn!("Trying to continue, incase the failing remote endpoint doesn't matter for this run.");
 						allowing_dag_errors = true;
-					} else {
-						warn!("Failed to fetch a file from the filesystem! Assuming this is a critical error.");
-						return Err(err.wrap_err(format!(
-							"Failed to read the file: [{}] from the filesystem",
-							task_location.get_at()
-						)));
+						continue;
 					}
-					continue;
+
+					warn!("Failed to fetch a file from the filesystem! Assuming this is a critical error.");
+					return Err(err.wrap_err(format!(
+						"Failed to read the file: [{}] from the filesystem",
+						task_location.get_at()
+					)));
 				}
 
-				let fetched_tasks = resulting_fetched_tasks.unwrap();
-				for task_conf_file in fetched_tasks {
+				for task_conf_file in resulting_fetched_tasks.unwrap() {
 					let task_yaml_res =
 						serde_yaml::from_slice::<TaskConfFile>(&task_conf_file.get_contents());
 					if let Err(tye) = task_yaml_res {
@@ -107,7 +174,7 @@ impl TaskGraph {
 							continue;
 						}
 
-						return contextualize_yaml_err(
+						return contextualize(
 							Err(tye),
 							task_conf_file.get_source(),
 							&String::from_utf8_lossy(task_conf_file.get_contents()).to_string()
@@ -122,66 +189,13 @@ impl TaskGraph {
 					// we're reading. So we have to allow for cases where a task _may_ not
 					// be parsed yet.
 					for task_conf in task_yaml.consume_tasks() {
-						let task_name = task_conf.get_name();
-
-						// If we've already seen this task... it's an error.
-						// Task names need to be globally unique.
-						if let Some(other_task_conf) = flatenned_tasks.get(task_name) {
-							return Err(eyre!(
-								"Found duplicate task named: [{}]. Originally defined in config at: [{}], found again in config at: [{}]",
-								task_name,
-								other_task_conf.get_source_path(),
-								task_conf_file.get_source(),
-							));
-						}
-
-						// If it's a 'oneof', 'parallel-pipeline', or 'pipeline' type, we
-						// need to parse it's children so we can ensure everything is valid.
-						//
-						// We call `internal_task_names.remove()` always (it'll be a no-op if it
-						// doesn't contain the key). The `internal_task_names` are tasks that are marked
-						// `internal: true`, but don't yet have a reference. By being in a
-						// oneof/parallel-pipeline/pipeline they themselves have a reference.
-						//
-						// Next we check if the option "exists", if not. we add it to `unsatisfied_task_names`
-						// so it can be checked later.
-						let ttype = task_conf.get_type();
-						match ttype {
-							TaskType::Oneof => {
-								if let Some(options) = task_conf.get_options() {
-									for option in options {
-										internal_task_names.remove(option.get_task_name());
-										if !flatenned_tasks.contains_key(option.get_task_name()) {
-											unsatisfied_task_names
-												.insert(option.get_task_name().to_owned());
-										}
-									}
-								}
-							}
-							TaskType::Pipeline | TaskType::ParallelPipeline => {
-								if let Some(steps) = task_conf.get_steps() {
-									for step in steps {
-										internal_task_names.remove(step.get_task_name());
-										if !flatenned_tasks.contains_key(step.get_task_name()) {
-											unsatisfied_task_names
-												.insert(step.get_task_name().to_owned());
-										}
-									}
-								}
-							}
-							TaskType::Command => {}
-						}
-
-						// If we're an internal task, and someone hasn't referenced us already
-						// go ahead and add ourselves to the list of "waiting for a ref" set.
-						if task_conf.is_internal() && !unsatisfied_task_names.contains(task_name) {
-							internal_task_names.insert(task_name.to_owned());
-						}
-						// NO-OP if we're not there, otherwise let people know we exist.
-						unsatisfied_task_names.remove(task_name);
-
-						// Add ourselves to the final map.
-						flatenned_tasks.insert(task_name.to_owned(), task_conf);
+						Self::parse_task(
+							task_conf_file.get_source(),
+							task_conf,
+							&mut internal_task_names,
+							&mut unsatisfied_task_names,
+							&mut flatenned_tasks,
+						)?;
 					}
 				}
 			}
@@ -231,12 +245,6 @@ impl TaskGraph {
 				flattened_tasks: HashMap::new(),
 			})
 		}
-	}
-
-	/// Get a full list of the tasks that are available.
-	#[must_use]
-	pub fn get_all_tasks(&self) -> &HashMap<String, TaskConf> {
-		&self.flattened_tasks
 	}
 
 	/// Consume the overlying tasks type, and get all the tasks.

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -5,14 +5,14 @@
 //! command ever needs to do something fancy.
 
 use atty::Stream;
-use colored::*;
+use colored::Colorize;
 use crossbeam_channel::Sender;
-use lazy_static::*;
+use lazy_static::lazy_static;
 use std::sync::Arc;
 use term_size::dimensions as terminal_dimensions;
 
-pub mod task_indicator;
-pub mod throttle;
+pub(crate) mod task_indicator;
+pub(crate) mod throttle;
 
 lazy_static! {
 	pub static ref TERM: Arc<Term> = Arc::new(Term::new());
@@ -142,7 +142,6 @@ impl Term {
 	/// Render a list of items with a particular description.
 	///
 	/// `list_with_descriptions`: A pair of <item, description>.
-	#[allow(unused_assignments)]
 	#[must_use]
 	pub fn render_list_with_description(
 		&self,
@@ -166,7 +165,7 @@ impl Term {
 		let mut result = String::new();
 
 		for (key, description) in list_with_descriptions {
-			let mut actual_key = String::new();
+			let mut actual_key;
 			if key.len() > 15 {
 				actual_key = key.chars().take(12).collect();
 				actual_key += "...";
@@ -213,7 +212,6 @@ impl Term {
 	///   1. The task indicator instance.
 	///   2. A channel sender to send logs (and the task that created them).
 	///   3. A channel sender to send task changes too.
-	#[allow(clippy::type_complexity)]
 	#[must_use]
 	pub fn create_task_indicator(
 		&self,
@@ -223,6 +221,10 @@ impl Term {
 		Sender<(String, String, bool)>,
 		Sender<task_indicator::TaskChange>,
 	) {
-		task_indicator::TaskIndicator::new(task_count, self.is_colour, self.is_colour_err)
+		task_indicator::TaskIndicator::new(
+			task_count,
+			self.should_color_stdout(),
+			self.should_color_stderr(),
+		)
 	}
 }

--- a/src/yaml_err.rs
+++ b/src/yaml_err.rs
@@ -88,7 +88,7 @@ fn did_you_mean_variant(err_msg: &str) -> Option<Vec<String>> {
 /// # Errors
 ///
 /// - If the first parameter error'd.
-pub fn contextualize_yaml_err<T>(
+pub fn contextualize<T>(
 	result: Result<T, YamlError>,
 	src_filepath: &str,
 	src_data: &str,


### PR DESCRIPTION
* as of the error reworking commit, tasks sometimes didn't erase
  lines when it should have. most specifically at the beginning
  of tasks being executed, and all tasks completing. this is now
  fixed, as the task_inidcator ignores logs that happened before
  it started, and properly counts how many lines it added, that it
  needs to erase.

* we've reworked all of the codebase, so almost all clippy warnings
  that were previously ignored, are no longer ignored, and code
  has been rewritten so the lint step passes.

  * There are some "clippy::too_many_arguments" being ignored,
    I intend to fix these, but these require more of a deft hand,
    and so I don't want to rush it. reworking may also not be needed
    once I try it. (This is currently the most ignored clippy warning
    according too: https://github.com/rust-lang/rust-clippy/issues/5418)
    and reasoning I agree with is there.
  * There is one: `#[allow(unused)]` for pipeline descriptions. This
    is true, it is unused right now, but I want to keep it in the
    schema because I do want to render the pipeline in list one day.
    I just haven't found quite a way to do it yet, but i added it in
    because I know I want to do it (and I don't want to remove it).

* this has also resulted in a giant split up of docker executor,
  so it is no longer all in one gigantic file. This really _really_
  needed to be done, so I'm glad I finally did it.