### PR TITLE
allow tasks to gracefully handle SIGINT

### DIFF
--- a/.dl/tasks/config/dl-tasks.yml
+++ b/.dl/tasks/config/dl-tasks.yml
@@ -20,6 +20,11 @@ tasks:
     description: host the documentation site at localhost:3000
     type: pipeline
     steps:
+      - name: install deps
+        task: npm-with-port
+        args:
+          - "docs/"
+          - "install"
       - name: run docs site
         task: npm-with-port
         args:

--- a/.dl/tasks/implementation/nodejs/dl-tasks.yml
+++ b/.dl/tasks/implementation/nodejs/dl-tasks.yml
@@ -13,6 +13,7 @@ tasks:
   - name: npm-with-port
     description: shell out to npm in a container that has port 3000 open
     internal: true
+    ctrlc_is_failure: false
     execution_needs:
       - name: nodejs-with-port
     location:

--- a/docs/docs/schemas/task-conf.md
+++ b/docs/docs/schemas/task-conf.md
@@ -55,3 +55,9 @@ Whether or not this task is "internal". If a task is internal it will not be sho
 cannot be run directly (it must be invoked through a `oneof`/`pipeline`/`parallel-pipeline`).
 All internal tasks must be used at least once, or an error will occur because it would be impossible
 for that task to do anything.
+
+- `ctrlc_is_failure`: Bool [OPTIONAL]
+
+Whether or not this task is a task that may need a Ctrl-C, and as such shouldn't
+mark ctrlc as a failure. Defaults to TRUE, since most tasks want to treat a Ctrl-C
+as a failure.

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -466,6 +466,9 @@ pub struct TaskConf {
 	/// If this task is "internal", e.g. should not be shown
 	/// in the "list" command.
 	internal: Option<bool>,
+	/// If this task should keep running until a user hits CtrlC. E.g.
+	/// Ctrl-C should not be marked as a failure.
+	ctrlc_is_failure: Option<bool>,
 	/// Represents the source path this task configuration file is at.
 	/// This is always overriden by dev-loop itself, and will never
 	/// use a user provided value.
@@ -546,6 +549,12 @@ impl TaskConf {
 	#[must_use]
 	pub fn is_internal(&self) -> bool {
 		self.internal.unwrap_or(false)
+	}
+
+	/// Determine if this task should treat Ctrl-C as failure.
+	#[must_use]
+	pub fn ctrlc_is_failure(&self) -> bool {
+		self.ctrlc_is_failure.unwrap_or(true)
 	}
 
 	/// Get the original path of this particular task.

--- a/src/executors/host.rs
+++ b/src/executors/host.rs
@@ -317,8 +317,14 @@ impl ExecutorTrait for Executor {
 
 			// Have we been requested to stop?
 			if should_stop.load(Ordering::Acquire) {
-				error!("Executor was told to stop! killing child...");
-				rc = 10;
+				if task.ctrlc_is_failure() {
+					error!("Executor was told to terminate as failure!");
+					rc = 10;
+				} else {
+					warn!("Executor was told to terminate! Stopping!");
+					rc = 0;
+				}
+
 				let _ = command_pid.kill();
 				break;
 			}

--- a/src/tasks/execution/mod.rs
+++ b/src/tasks/execution/mod.rs
@@ -238,8 +238,8 @@ pub async fn execute_tasks_in_parallel(
 		task_indicator.tick();
 
 		if has_ctrlc_been_hit() {
-			debug!("Detected Ctrl-C being hit! Setting RC to 10, and shutting down.");
-			rc = 10;
+			debug!("Detected Ctrl-C being hit! Shutting down.");
+			should_stop.store(true, Ordering::Release);
 		}
 
 		if rc != 0 {


### PR DESCRIPTION
This will allow for things like serve-docs to gracefully handle SIGINT, or `ctrl-c` without failing and leaving a container running.