### PR TITLE
allow authentication for docker registries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,6 +507,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "atty",
+ "base64",
  "cfg-if",
  "color-eyre",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ annotate-snippets = { version = "^0.9", features = ["color"] }
 async-std = { version = "^1.6", features = ["attributes"] }
 async-trait = "^0.1"
 atty = "^0.2"
+base64 = "^0.12"
 colored = "^2.0"
 color-eyre = "^0.5.5"
 crossbeam-channel = "^0.4"

--- a/docs/docs/schemas/executor-conf.md
+++ b/docs/docs/schemas/executor-conf.md
@@ -51,7 +51,9 @@ The Host Executor has no possible arguments. It ignores all possible options.
 | tcp_ports_to_expose            | Comma Seperated String [OPTIONAL]          | a comma seperated list of ports to export to the host machine. you won't need to set these if you're using two tasks in a pipeline, as each pipeline gets it's own docker network that allows services to natively communicate. |
 | udp_ports_to_expose            | Comma Seperated String [OPTIONAL]          | the same as `tcp_ports_to_export` just for udp instead.                                                                                                                                                                         |
 | experimental_permission_helper | String'd Boolean [OPTIONAL] [EXPERIMENTAL] | [EXPERIMENTAL] will break in a later update, a flag that tells dev-loop to fix permissions on linux hosts for it's mounted volumes.                                                                                             |
-
+| run_until_ctrlc                | String'd Boolean [OPTIONAL]                | Used to indicate that a task will run until Ctrl-C is pressed. Effectively will not cause a failure when Ctrl-C is pressed.                                                                                                     |
+| docker_auth_username_env       | String                                     | The environment variable that contains the username for authentication.                                                                                                                                                         |
+| docker_auth_password_env       | String                                     | The environment variable that contains the password for authentication.                                                                                                                                                         |
 - `provides`: List[<a href="/docs/schemas/provide-conf" class="internal-link">ProvideConf</a>] [OPTIONAL]
 
 A list of things this particular executor provides. See ProvideConf for more information.

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -16,6 +16,31 @@ pub struct ProvideConf {
 	version: Option<String>,
 }
 
+impl ProvideConf {
+	/// Create a new implementation of `ProvideConf`
+	#[cfg(test)]
+	#[must_use]
+	pub fn new(name: String, version: Option<String>) -> Self {
+		Self { name, version }
+	}
+
+	/// Get the name of the thing provided.
+	#[must_use]
+	pub fn get_name(&self) -> &str {
+		&self.name
+	}
+
+	/// Get the version of the thing provided.
+	#[must_use]
+	pub fn get_version(&self) -> &str {
+		if self.version.is_none() {
+			""
+		} else {
+			self.version.as_ref().unwrap()
+		}
+	}
+}
+
 /// All of the possible types of executors that dev-loop supports executing.
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub enum ExecutorType {
@@ -41,31 +66,6 @@ pub struct ExecutorConf {
 	params: Option<HashMap<String, String>>,
 	/// The list of provided installed utilities.
 	provides: Option<Vec<ProvideConf>>,
-}
-
-impl ProvideConf {
-	/// Create a new implementation of `ProvideConf`
-	#[cfg(test)]
-	#[must_use]
-	pub fn new(name: String, version: Option<String>) -> Self {
-		Self { name, version }
-	}
-
-	/// Get the name of the thing provided.
-	#[must_use]
-	pub fn get_name(&self) -> &str {
-		&self.name
-	}
-
-	/// Get the version of the thing provided.
-	#[must_use]
-	pub fn get_version(&self) -> &str {
-		if self.version.is_none() {
-			""
-		} else {
-			self.version.as_ref().unwrap()
-		}
-	}
 }
 
 impl ExecutorConf {

--- a/src/executors/docker.rs
+++ b/src/executors/docker.rs
@@ -21,7 +21,7 @@ use color_eyre::{
 use crossbeam_channel::Sender;
 use isahc::{
 	config::{Dialer, VersionNegotiation},
-	http::{HeaderMap, header::HeaderName},
+	http::{header::HeaderName, HeaderMap},
 	prelude::*,
 	Error as HttpError, HttpClient, HttpClientBuilder,
 };
@@ -121,13 +121,20 @@ impl Executor {
 								username_ref,
 								password_ref,
 								opening_bracket = "{",
-							)).parse()?,
+							))
+							.parse()?,
 						);
 					} else {
-						warn!("No password variable specified in: [{}], not authenticating", pass_env_var);
+						warn!(
+							"No password variable specified in: [{}], not authenticating",
+							pass_env_var
+						);
 					}
 				} else {
-					warn!("No username variable specified in: [{}], not authenticating", user_env_var);
+					warn!(
+						"No username variable specified in: [{}], not authenticating",
+						user_env_var
+					);
 				}
 			} else {
 				warn!("`docker_auth_username_env` specified with no `docker_auth_password_env`, not authenticating.");


### PR DESCRIPTION
Third-Party Docker registries sometimes need an extra authentication header specified in order to properly allow authentication. This patch adds in extra args, which allows users to specify their authentication info through environment variables in order to authenticate to third party registries that require it.